### PR TITLE
Convert values of unit columns to lower case when filtering

### DIFF
--- a/apps/frontend/src/app/workspace/components/unit-table/unit-table.component.ts
+++ b/apps/frontend/src/app/workspace/components/unit-table/unit-table.component.ts
@@ -51,7 +51,9 @@ export class UnitTableComponent implements AfterViewInit, OnChanges {
     this.dataSource = new MatTableDataSource(this.unitList);
     this.dataSource
       .filterPredicate = (unitList, filter) => this.displayedColumns
-        .some(column => (unitList[column as keyof UnitInListDto] as string).indexOf(filter) > -1);
+        .some(column => (unitList[column as keyof UnitInListDto] as string)
+          .toLowerCase()
+          .includes(filter));
   }
 
   onSortChange($event: Sort): void {


### PR DESCRIPTION
Casting as string works only for strings with the length of 1