### PR TITLE
[bugfix] Pack the unit IDs into the body of the message

### DIFF
--- a/apps/api/src/app/workspace/workspace.controller.ts
+++ b/apps/api/src/app/workspace/workspace.controller.ts
@@ -1,9 +1,8 @@
 import {
-  Body,
-  Controller, Delete, Get, Header, Param, Patch, Post, Query, StreamableFile, UploadedFiles, UseGuards, UseInterceptors
+  Body, Controller, Delete, Get, Header, Param, Patch, Post, StreamableFile, UploadedFiles, UseGuards, UseInterceptors
 } from '@nestjs/common';
 import {
-  ApiBearerAuth, ApiCreatedResponse, ApiQuery, ApiTags
+  ApiBearerAuth, ApiCreatedResponse, ApiTags
 } from '@nestjs/swagger';
 import {
   WorkspaceFullDto, RequestReportDto, WorkspaceSettingsDto, UsersInWorkspaceDto
@@ -87,25 +86,21 @@ export class WorkspaceController {
   async renameUnitGroup(@WorkspaceId() workspaceId: number,
     @Param('name') oldGroupName: string,
     @Body() newGroupName) {
-    const b = Buffer.from(oldGroupName, 'hex');
-    return this.workspaceService.patchGroupName(workspaceId, b.toString(), newGroupName.body);
+    return this.workspaceService
+      .patchGroupName(workspaceId, Buffer.from(oldGroupName, 'hex').toString(), newGroupName.body);
   }
 
   @Patch('group/:name/units')
   @UseGuards(JwtAuthGuard, WorkspaceGuard)
   @ApiBearerAuth()
   @ApiImplicitParam({ name: 'workspace_id', type: Number })
-  @ApiQuery({
-    name: 'units',
-    type: String
-  })
   @ApiTags('workspace')
   async patchUnitsGroup(@WorkspaceId() workspaceId: number,
     @Param('name') groupName: string,
-    @Query('units') ids: string) {
-    const b = Buffer.from(groupName, 'hex');
-    const idsAsNumberArray = ids ? ids.split(';').map(s => parseInt(s, 10)) : [];
-    return this.workspaceService.patchUnitsGroup(workspaceId, b.toString(), idsAsNumberArray);
+    @Body() body
+  ) {
+    return this.workspaceService
+      .patchUnitsGroup(workspaceId, Buffer.from(groupName, 'hex').toString(), body.units);
   }
 
   @Delete('group/:name')
@@ -114,8 +109,8 @@ export class WorkspaceController {
   @ApiImplicitParam({ name: 'workspace_id', type: Number })
   @ApiTags('workspace')
   async deleteUnitGroup(@WorkspaceId() workspaceId: number, @Param('name') groupName: string) {
-    const b = Buffer.from(groupName, 'hex');
-    return this.workspaceService.removeGroup(workspaceId, b.toString());
+    return this.workspaceService
+      .removeGroup(workspaceId, Buffer.from(groupName, 'hex').toString());
   }
 
   @Post('upload')

--- a/apps/frontend/src/app/modules/workspace/services/backend.service.ts
+++ b/apps/frontend/src/app/modules/workspace/services/backend.service.ts
@@ -279,9 +279,9 @@ export class BackendService {
 
   renameUnitGroup(workspaceId: number, oldGroupName: string, newGroupName: string): Observable<boolean> {
     return this.http
-      .patch(`${this.serverUrl}workspace/${workspaceId}/group/${
-        BackendService.utf8AsHexString(oldGroupName)
-      }`, { body: newGroupName })
+      .patch(
+        `${this.serverUrl}workspace/${workspaceId}/group/${BackendService.utf8AsHexString(oldGroupName)}`,
+        { body: newGroupName })
       .pipe(
         map(() => true),
         catchError(() => of(false))
@@ -290,9 +290,9 @@ export class BackendService {
 
   setGroupUnits(workspaceId: number, groupName: string, units: number[]): Observable<boolean> {
     return this.http
-      .patch(`${this.serverUrl}workspace/${workspaceId}/group/${
-        BackendService.utf8AsHexString(groupName)
-      }/units?units=${units.join(';')}`, {})
+      .patch(
+        `${this.serverUrl}workspace/${workspaceId}/group/${BackendService.utf8AsHexString(groupName)}/units`,
+        { units })
       .pipe(
         map(() => true),
         catchError(() => of(false))


### PR DESCRIPTION
instead of sending them as query parameters.
The self-created query parameters were not parsed correctly (since using Traefik?)