### PR TITLE
[frontend] Remove NestedTreeComponent warning in the browser console

### DIFF
--- a/apps/frontend/src/app/modules/metadata/components/nested-tree/nested-tree.component.html
+++ b/apps/frontend/src/app/modules/metadata/components/nested-tree/nested-tree.component.html
@@ -50,7 +50,7 @@
     <button mat-raised-button
             color="primary"
             type="submit"
-            [mat-dialog-close]="{nodes:getSelectedNodesList(),hideNumbering:dialogData.props?.hideNumbering}">
+            [mat-dialog-close]="{nodes:getSelectedNodesList(),hideNumbering:dialogData.props.hideNumbering}">
         {{'confirm' | translate}}
     </button>
     <button mat-raised-button

--- a/apps/frontend/src/app/modules/metadata/components/nested-tree/nested-tree.component.spec.ts
+++ b/apps/frontend/src/app/modules/metadata/components/nested-tree/nested-tree.component.spec.ts
@@ -21,7 +21,11 @@ describe('NestedTreeNodeComponent', () => {
       providers: [
         {
           provide: MAT_DIALOG_DATA,
-          useValue: {}
+          useValue: {
+            value: null,
+            props: {},
+            vocabularies: []
+          }
         }
       ]
 


### PR DESCRIPTION
Warning: "The left side of this optional chain operation does not include 'null' or 'undefined' in its type, therefore the '?.' operator can be replaced with the '.' operator."