### PR TITLE
Kodierbericht: Download-Button, Schulungsaufwand und sprechendere Kodiertypen

### DIFF
--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import {
   CreateWorkspaceDto, UserWorkspaceAccessDto, WorkspaceSettingsDto, RenameGroupNameDto
 } from '@studio-lite-lib/api-dto';
+import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import { WorkspaceService } from './workspace.service';
 import Workspace from '../entities/workspace.entity';
 import WorkspaceUser from '../entities/workspace-user.entity';
@@ -296,6 +297,60 @@ describe('WorkspaceService', () => {
       (unitService.findAllWithProperties as jest.Mock).mockResolvedValue([]);
       const result = await service.getCodingReport(1);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('determineCodingType', () => {
+    it('maps closed coding to automatisch', () => {
+      const codingType = WorkspaceService.determineCodingType({
+        codes: [{
+          type: 'RESIDUAL_AUTO',
+          manualInstruction: '',
+          ruleSets: [{ rules: [] }]
+        }]
+      } as unknown as VariableCodingData);
+
+      expect(codingType).toBe('automatisch');
+    });
+
+    it('maps rules-based coding to halbautomatisch', () => {
+      const codingType = WorkspaceService.determineCodingType({
+        codes: [{
+          manualInstruction: '',
+          ruleSets: [{ rules: [{ method: 'MATCH', parameters: ['a'] }] }]
+        }]
+      } as unknown as VariableCodingData);
+
+      expect(codingType).toBe('halbautomatisch');
+    });
+
+    it('maps manual coding to manuell', () => {
+      const codingType = WorkspaceService.determineCodingType({
+        codes: [{
+          manualInstruction: 'Hinweis',
+          ruleSets: [{ rules: [] }]
+        }]
+      } as unknown as VariableCodingData);
+
+      expect(codingType).toBe('manuell');
+    });
+  });
+
+  describe('determineTrainingEffort', () => {
+    it('returns erhöht when CODER_TRAINING_REQUIRED is set', () => {
+      const trainingEffort = WorkspaceService.determineTrainingEffort({
+        processing: ['CODER_TRAINING_REQUIRED']
+      } as unknown as VariableCodingData);
+
+      expect(trainingEffort).toBe('erhöht');
+    });
+
+    it('returns normal when CODER_TRAINING_REQUIRED is not set', () => {
+      const trainingEffort = WorkspaceService.determineTrainingEffort({
+        processing: []
+      } as unknown as VariableCodingData);
+
+      expect(trainingEffort).toBe('normal');
     });
   });
 

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -404,6 +404,9 @@ export class WorkspaceService {
           codingVariable
         );
         const codingType = WorkspaceService.determineCodingType(codingVariable);
+        const trainingEffort = WorkspaceService.determineTrainingEffort(
+          codingVariable
+        );
         const foundItem = WorkspaceService.findMatchingItem(
           unit,
           codingVariable
@@ -414,7 +417,8 @@ export class WorkspaceService {
           variable: codingVariable.alias || codingVariable.id || '–',
           item: foundItem?.id || '–',
           validation: validationResultText,
-          codingType: codingType
+          codingType: codingType,
+          trainingEffort: trainingEffort
         });
       });
   }
@@ -453,10 +457,16 @@ export class WorkspaceService {
       );
     });
 
-    if (closedCoding) return 'geschlossen';
+    if (closedCoding) return 'automatisch';
     if (manualCodingOnly) return 'manuell';
-    if (hasRules) return 'regelbasiert';
+    if (hasRules) return 'halbautomatisch';
     return 'keine Regeln';
+  }
+
+  static determineTrainingEffort(codingVariable: VariableCodingData): string {
+    return codingVariable.processing?.includes('CODER_TRAINING_REQUIRED') ?
+      'erhöht' :
+      'normal';
   }
 
   static findMatchingItem(
@@ -487,7 +497,8 @@ export class WorkspaceService {
       variable: '',
       item: '',
       validation: 'Kodierschema mit Schemer Version ab 1.5 erzeugen!',
-      codingType: ''
+      codingType: '',
+      trainingEffort: ''
     });
   }
 

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
@@ -28,10 +28,16 @@
 <mat-dialog-actions align="end" >
   <button mat-raised-button
           color="primary"
+          type="button"
+          data-cy="coding-report-download"
+          (click)="downloadCodingReport()">
+    {{ 'download' | translate }}
+  </button>
+  <button mat-raised-button
+          color="primary"
           type="submit"
           [mat-dialog-close]="">
     {{ 'close' | translate }}
   </button>
 </mat-dialog-actions>
-
 

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.scss
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.scss
@@ -16,3 +16,7 @@ td , th {
 .title{
   display: inline !important
 }
+
+mat-dialog-actions {
+  gap: 10px;
+}

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
@@ -23,14 +23,16 @@ describe('CodingReportComponent', () => {
       variable: 'V1',
       item: 'I1',
       validation: 'ok',
-      codingType: 'keine Regeln'
+      codingType: 'keine Regeln',
+      trainingEffort: 'normal'
     } as CodingReportDto,
     {
       unit: 'U1',
       variable: 'V2',
       item: 'I2',
       validation: 'ok',
-      codingType: 'REGEL'
+      codingType: 'REGEL',
+      trainingEffort: 'erhöht'
     } as CodingReportDto
   ];
 
@@ -89,5 +91,32 @@ describe('CodingReportComponent', () => {
     component.applyFilter(event);
 
     expect(component.dataSource.filter).toBe('v2');
+  });
+
+  it('downloadCodingReport creates and revokes object URL', () => {
+    const createObjectURLMock = jest.fn(() => 'blob:test-url');
+    const revokeObjectURLMock = jest.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: createObjectURLMock,
+      writable: true
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: revokeObjectURLMock,
+      writable: true
+    });
+    const clickMock = jest.fn();
+    const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: clickMock
+    } as unknown as HTMLAnchorElement);
+
+    component.downloadCodingReport();
+
+    expect(createObjectURLMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:test-url');
+
+    createElementSpy.mockRestore();
   });
 });

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -38,7 +38,14 @@ import { WorkspaceBackendService } from '../../services/workspace-backend.servic
 })
 export class CodingReportComponent implements OnInit {
   // Columns to display in the table
-  displayedColumns: string[] = ['unit', 'variable', 'item', 'validation', 'codingType'];
+  displayedColumns: string[] = [
+    'unit',
+    'variable',
+    'item',
+    'validation',
+    'codingType',
+    'trainingEffort'
+  ];
   dataSource!: MatTableDataSource<CodingReportDto>; // Datasource for the table
   isLoading = false; // Indicates if data is currently loading
   codedVariablesOnly = true; // Filter: Display only coded variables
@@ -115,5 +122,46 @@ export class CodingReportComponent implements OnInit {
   toggleChange(): void {
     this.codedVariablesOnly = !this.codedVariablesOnly;
     this.updateDataSource();
+  }
+
+  downloadCodingReport(): void {
+    const rows = this.dataSource?.filteredData || [];
+    const headers = this.displayedColumns
+      .map(column => this.getCsvHeader(column as keyof CodingReportDto))
+      .join(';');
+    const csvRows = rows.map(row => this.displayedColumns
+      .map(column => this.escapeCsvValue(this.stripHtml(String(
+        row[column as keyof CodingReportDto] ?? ''
+      ))))
+      .join(';')
+    );
+    const csvContent = `\uFEFF${[headers, ...csvRows].join('\n')}`;
+    const file = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const fileUrl = URL.createObjectURL(file);
+    const link = document.createElement('a');
+    link.href = fileUrl;
+    link.download = 'kodierbericht.csv';
+    link.click();
+    URL.revokeObjectURL(fileUrl);
+  }
+
+  private escapeCsvValue(value: string): string {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  private stripHtml(value: string): string {
+    return value.replace(/<[^>]+>/g, '');
+  }
+
+  private getCsvHeader(column: keyof CodingReportDto): string {
+    const headers: Record<keyof CodingReportDto, string> = {
+      unit: 'Aufgabe',
+      variable: 'Variable',
+      item: 'Item',
+      validation: 'Validierung',
+      codingType: 'Kodiertyp',
+      trainingEffort: 'Schulungsaufwand'
+    };
+    return headers[column];
   }
 }

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -150,7 +150,15 @@ export class CodingReportComponent implements OnInit {
   }
 
   private stripHtml(value: string): string {
-    return value.replace(/<[^>]+>/g, '');
+    let sanitized = value;
+    let previous: string;
+
+    do {
+      previous = sanitized;
+      sanitized = sanitized.replace(/<[^>]+>/g, '');
+    } while (sanitized !== previous);
+
+    return sanitized;
   }
 
   private getCsvHeader(column: keyof CodingReportDto): string {

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -46,6 +46,7 @@ export class CodingReportComponent implements OnInit {
     'codingType',
     'trainingEffort'
   ];
+
   dataSource!: MatTableDataSource<CodingReportDto>; // Datasource for the table
   isLoading = false; // Indicates if data is currently loading
   codedVariablesOnly = true; // Filter: Display only coded variables
@@ -127,10 +128,10 @@ export class CodingReportComponent implements OnInit {
   downloadCodingReport(): void {
     const rows = this.dataSource?.filteredData || [];
     const headers = this.displayedColumns
-      .map(column => this.getCsvHeader(column as keyof CodingReportDto))
+      .map(column => CodingReportComponent.getCsvHeader(column as keyof CodingReportDto))
       .join(';');
     const csvRows = rows.map(row => this.displayedColumns
-      .map(column => this.escapeCsvValue(this.stripHtml(String(
+      .map(column => CodingReportComponent.escapeCsvValue(CodingReportComponent.stripHtml(String(
         row[column as keyof CodingReportDto] ?? ''
       ))))
       .join(';')
@@ -145,11 +146,11 @@ export class CodingReportComponent implements OnInit {
     URL.revokeObjectURL(fileUrl);
   }
 
-  private escapeCsvValue(value: string): string {
+  private static escapeCsvValue(value: string): string {
     return `"${value.replace(/"/g, '""')}"`;
   }
 
-  private stripHtml(value: string): string {
+  private static stripHtml(value: string): string {
     let sanitized = value;
     let previous: string;
 
@@ -161,7 +162,7 @@ export class CodingReportComponent implements OnInit {
     return sanitized;
   }
 
-  private getCsvHeader(column: keyof CodingReportDto): string {
+  private static getCsvHeader(column: keyof CodingReportDto): string {
     const headers: Record<keyof CodingReportDto, string> = {
       unit: 'Aufgabe',
       variable: 'Variable',

--- a/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.spec.ts
@@ -711,7 +711,8 @@ describe('WorkspaceBackendService', () => {
           variable: 'var1',
           item: 'item1',
           validation: 'ok',
-          codingType: 'manual'
+          codingType: 'manual',
+          trainingEffort: 'normal'
         }
       ];
 

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -805,7 +805,8 @@
     "variable": "Variable",
     "item": "Item",
     "validation": "Validierung",
-    "codingType": "Kodiertyp"
+    "codingType": "Kodiertyp",
+    "trainingEffort": "Schulungsaufwand"
   },
   "unit-properties": {
     "title": "Aufgaben-Eigenschaften",

--- a/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
+++ b/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
@@ -15,4 +15,7 @@ export class CodingReportDto {
 
   @ApiProperty()
     codingType!: string;
+
+  @ApiProperty()
+    trainingEffort!: string;
 }


### PR DESCRIPTION
## Hintergrund
Umsetzung von #1420.

## Änderungen
- Download-Button im Dialog "Kodierbericht" ergänzt (CSV-Export der aktuell gefilterten Tabelle).
- Neue Spalte `Schulungsaufwand` im Kodierbericht ergänzt.
- Ableitung über `CODER_TRAINING_REQUIRED` implementiert:
  - gesetzt -> `erhöht`
  - nicht gesetzt -> `normal`
- Kodiertyp-Bezeichnungen im Report angepasst:
  - `geschlossen` -> `automatisch`
  - `regelbasiert` -> `halbautomatisch`
  - `manuell` bleibt `manuell`
- DTO, Backend-Mapping, Frontend-Tabelle und Tests entsprechend aktualisiert.

## Tests
- `npx nx test api --runInBand --testPathPattern=apps/api/src/app/services/workspace.service.spec.ts`
- `npx nx test frontend --runInBand --testPathPattern=apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts`

Closes #1420