### PR TITLE
Fix DOCX corruption when manual instruction formulas are exported

### DIFF
--- a/apps/api/src/app/classes/download-docx.class.spec.ts
+++ b/apps/api/src/app/classes/download-docx.class.spec.ts
@@ -151,6 +151,43 @@ describe('DownloadDocx', () => {
   });
 
   describe('Utility methods', () => {
+    it('should sanitize invalid XML chars inside OMML text nodes', () => {
+      const downloadDocx = DownloadDocx as unknown as {
+        sanitizeOmmlXml: (omml: string) => string;
+      };
+      const rawOmml = '<m:oMath><m:r><m:t xml:space="preserve">a<b & c</m:t></m:r></m:oMath>';
+      const sanitizedOmml = downloadDocx.sanitizeOmmlXml(rawOmml);
+
+      expect(sanitizedOmml).toContain('a&lt;b &amp; c');
+      expect(sanitizedOmml).not.toContain('a<b & c');
+    });
+
+    it('should sanitize OMML before creating ImportedXmlComponent', () => {
+      const fromXmlString = (
+        jest.requireMock('docx') as {
+          ImportedXmlComponent: { fromXmlString: jest.Mock };
+        }
+      ).ImportedXmlComponent.fromXmlString;
+      fromXmlString.mockClear();
+
+      const mml2ommlMock = (
+        jest.requireMock('mathml2omml') as { mml2omml: jest.Mock }
+      ).mml2omml;
+      mml2ommlMock.mockReturnValueOnce(
+        '<m:oMath><m:r><m:t xml:space="preserve">a<b & c</m:t></m:r></m:oMath>'
+      );
+
+      const downloadDocx = DownloadDocx as unknown as {
+        latexToOmml: (latex: string) => unknown;
+      };
+      const result = downloadDocx.latexToOmml('a<b');
+
+      expect(result).toEqual({});
+      expect(fromXmlString).toHaveBeenCalledWith(
+        '<m:oMath><m:r><m:t xml:space="preserve">a&lt;b &amp; c</m:t></m:r></m:oMath>'
+      );
+    });
+
     it('parseCssRgbString should parse rgb and rgba correctly', () => {
       const downloadDocx = DownloadDocx as unknown as {
         parseCssRgbString: (input: string) => number[];

--- a/apps/api/src/app/classes/download-docx.class.ts
+++ b/apps/api/src/app/classes/download-docx.class.ts
@@ -744,6 +744,49 @@ export class DownloadDocx {
       component;
   }
 
+  private static isMathComponent(
+    child: ParagraphChild
+  ): child is ImportedXmlComponent {
+    if (typeof child !== 'object' || child === null) {
+      return false;
+    }
+    const importedChild = child as ImportedXmlComponent & {
+      rootKey?: string;
+    };
+    return importedChild.rootKey === 'm:oMath' ||
+      importedChild.rootKey === 'm:oMathPara';
+  }
+
+  private static createLeftAlignedMathParagraph(
+    mathChildren: ImportedXmlComponent[]
+  ): ImportedXmlComponent {
+    const mathParagraph = new ImportedXmlComponent('m:oMathPara');
+    const mathParagraphProperties = new ImportedXmlComponent('m:oMathParaPr');
+    mathParagraphProperties.push(
+      new ImportedXmlComponent('m:jc', { 'm:val': 'left' })
+    );
+    mathParagraph.push(mathParagraphProperties);
+    mathChildren.forEach(mathChild => mathParagraph.push(mathChild));
+    return mathParagraph;
+  }
+
+  private static normalizeParagraphChildren(
+    children: ParagraphChild[]
+  ): ParagraphChild[] {
+    if (!children.length) {
+      return children;
+    }
+
+    const mathChildren = children.filter(
+      DownloadDocx.isMathComponent
+    ) as ImportedXmlComponent[];
+    if (mathChildren.length === children.length) {
+      return [DownloadDocx.createLeftAlignedMathParagraph(mathChildren)];
+    }
+
+    return children;
+  }
+
   private static sanitizeOmmlXml(omml: string): string {
     if (!omml) return omml;
     return omml.replace(
@@ -889,6 +932,9 @@ export class DownloadDocx {
       backgroundColor,
       size
     );
+    const normalizedChildren = DownloadDocx.normalizeParagraphChildren(
+      children
+    );
     return new Paragraph({
       alignment: DownloadDocx.getAlignment(textAlignment),
       spacing: {
@@ -897,7 +943,7 @@ export class DownloadDocx {
       },
       indent: !isListParagraph ? { start: 100, end: 100 } : null,
       bullet: isListParagraph ? { level: 0 } : null,
-      children: children
+      children: normalizedChildren
     });
   }
 

--- a/apps/api/src/app/classes/download-docx.class.ts
+++ b/apps/api/src/app/classes/download-docx.class.ts
@@ -717,10 +717,31 @@ export class DownloadDocx {
         strict: 'ignore'
       });
       const omml = mml2omml(mathml);
-      return ImportedXmlComponent.fromXmlString(omml);
+      return ImportedXmlComponent.fromXmlString(
+        DownloadDocx.sanitizeOmmlXml(omml)
+      );
     } catch {
       return null;
     }
+  }
+
+  private static sanitizeOmmlXml(omml: string): string {
+    if (!omml) return omml;
+    return omml.replace(
+      /(<m:t\b[^>]*>)([\s\S]*?)(<\/m:t>)/g,
+      (_, prefix: string, rawText: string, suffix: string) =>
+        `${prefix}${DownloadDocx.escapeXmlText(rawText)}${suffix}`
+    );
+  }
+
+  private static escapeXmlText(text: string): string {
+    return text
+      .replace(
+        /&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);)/g,
+        '&amp;'
+      )
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   private static normalizeMathTokens(html: string): string {

--- a/apps/api/src/app/classes/download-docx.class.ts
+++ b/apps/api/src/app/classes/download-docx.class.ts
@@ -717,12 +717,31 @@ export class DownloadDocx {
         strict: 'ignore'
       });
       const omml = mml2omml(mathml);
-      return ImportedXmlComponent.fromXmlString(
+      return DownloadDocx.unwrapImportedXmlRoot(
+        ImportedXmlComponent.fromXmlString(
         DownloadDocx.sanitizeOmmlXml(omml)
+        )
       );
     } catch {
       return null;
     }
+  }
+
+  private static unwrapImportedXmlRoot(
+    component: ImportedXmlComponent
+  ): ImportedXmlComponent {
+    const importedComponent = component as ImportedXmlComponent & {
+      root?: Array<ImportedXmlComponent | string>;
+      rootKey?: string;
+    };
+    if (importedComponent.rootKey !== undefined) {
+      return component;
+    }
+
+    const firstChild = importedComponent.root?.[0];
+    return typeof firstChild === 'object' && firstChild !== null ?
+      firstChild as ImportedXmlComponent :
+      component;
   }
 
   private static sanitizeOmmlXml(omml: string): string {

--- a/apps/api/src/app/classes/download-docx.class.ts
+++ b/apps/api/src/app/classes/download-docx.class.ts
@@ -719,7 +719,7 @@ export class DownloadDocx {
       const omml = mml2omml(mathml);
       return DownloadDocx.unwrapImportedXmlRoot(
         ImportedXmlComponent.fromXmlString(
-        DownloadDocx.sanitizeOmmlXml(omml)
+          DownloadDocx.sanitizeOmmlXml(omml)
         )
       );
     } catch {
@@ -791,8 +791,7 @@ export class DownloadDocx {
     if (!omml) return omml;
     return omml.replace(
       /(<m:t\b[^>]*>)([\s\S]*?)(<\/m:t>)/g,
-      (_, prefix: string, rawText: string, suffix: string) =>
-        `${prefix}${DownloadDocx.escapeXmlText(rawText)}${suffix}`
+      (_, prefix: string, rawText: string, suffix: string) => `${prefix}${DownloadDocx.escapeXmlText(rawText)}${suffix}`
     );
   }
 
@@ -872,31 +871,6 @@ export class DownloadDocx {
       'xx-large'
     ];
     return sizeTypes.includes(size) ? 20 : parseInt(size, 10);
-  }
-
-  private static getTextRun(
-    cheerioAPI: cheerio.CheerioAPI,
-    child: AnyNodeWithName,
-    colorParsed: string,
-    backgroundColor: string,
-    size: string
-  ): TextRun {
-    const tag = child.name;
-    return new TextRun({
-      text: cheerioAPI(child).text(),
-      color: colorParsed,
-      shading: {
-        fill: backgroundColor
-      },
-      break: tag === 'br' ? 1 : null,
-      underline: tag === 'u' ? {} : null,
-      bold: tag === 'strong',
-      italics: tag === 'em',
-      strike: tag === 's',
-      subScript: tag === 'sub',
-      superScript: tag === 'sup',
-      size: DownloadDocx.getFontSize(size)
-    });
   }
 
   private static getAlignment(

--- a/apps/api/src/app/classes/download-docx.integration.spec.ts
+++ b/apps/api/src/app/classes/download-docx.integration.spec.ts
@@ -91,6 +91,30 @@ describe('DownloadDocx integration', () => {
     expect(documentXml).not.toContain('a<b</m:t>');
   });
 
+  it('exports formula-only paragraphs as left-aligned math paragraphs for Word', async () => {
+    const description = '<p><span class="iqb-math-formula" data-latex="e^2=m"></span></p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(() => create(documentXml)).not.toThrow();
+    expect(documentXml).toContain('<m:oMathPara>');
+    expect(documentXml).toContain('<m:oMathParaPr><m:jc m:val="left"/></m:oMathParaPr>');
+    expect(documentXml).toContain('<m:oMath');
+  });
+
+  it('keeps inline formulas inline when a paragraph also contains text', async () => {
+    const description =
+      '<p>Prefix <span class="iqb-math-formula" data-latex="e^2=m"></span> suffix</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(() => create(documentXml)).not.toThrow();
+    expect(documentXml).not.toContain('<m:oMathPara>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('Prefix');
+    expect(documentXml).toContain('suffix');
+  });
+
   it('keeps the DOCX valid when unsupported formulas fall back to plain text', async () => {
     const description =
       '<p>Formel: ' +

--- a/apps/api/src/app/classes/download-docx.integration.spec.ts
+++ b/apps/api/src/app/classes/download-docx.integration.spec.ts
@@ -1,0 +1,108 @@
+import AdmZip = require('adm-zip');
+import { create } from 'xmlbuilder2';
+import {
+  CodebookUnitDto,
+  CodeBookContentSetting
+} from '@studio-lite-lib/api-dto';
+import { DownloadDocx } from './download-docx.class';
+
+const defaultSettings = {
+  showScore: false,
+  hideItemVarRelation: false,
+  hasGeneralInstructions: false,
+  hasOnlyVarsWithCodes: false
+} as unknown as CodeBookContentSetting;
+
+const buildUnits = (description: string): CodebookUnitDto[] => [
+  {
+    key: 'U1',
+    name: 'Unit 1',
+    missings: [],
+    items: [
+      {
+        id: 'ITEM1',
+        variableId: 'V1'
+      }
+    ],
+    variables: [
+      {
+        id: 'V1',
+        label: 'Variable 1',
+        generalInstruction: '',
+        codes: [
+          {
+            id: '1',
+            label: 'Label 1',
+            score: '1',
+            description
+          }
+        ]
+      }
+    ]
+  }
+] as unknown as CodebookUnitDto[];
+
+const getDocumentXml = async (description: string): Promise<string> => {
+  const buffer = await DownloadDocx.getDocXCodebook(
+    buildUnits(description),
+    defaultSettings
+  );
+  const zip = new AdmZip(buffer as Buffer);
+  return zip.readAsText('word/document.xml');
+};
+
+describe('DownloadDocx integration', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('creates valid DOCX XML for Schemer formula spans with raw latex in data-latex', async () => {
+    const description =
+      '<p>Formel: ' +
+      '<span class="iqb-math-formula" data-latex="a<b">' +
+      '<span><math><semantics><mrow><mi>a</mi><mo>&lt;</mo><mi>b</mi></mrow></semantics></math></span>' +
+      '</span>' +
+      '</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(() => create(documentXml)).not.toThrow();
+    expect(documentXml).not.toContain('<undefined>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('a&lt;b');
+    expect(documentXml).not.toContain('a<b</m:t>');
+  });
+
+  it('creates valid DOCX XML for iqb-math tokens with inequality latex', async () => {
+    const description = '<p>Formel: [[iqb-math:a%3Cb]]</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(() => create(documentXml)).not.toThrow();
+    expect(documentXml).not.toContain('<undefined>');
+    expect(documentXml).toContain('<m:oMath');
+    expect(documentXml).toContain('a&lt;b');
+    expect(documentXml).not.toContain('a<b</m:t>');
+  });
+
+  it('keeps the DOCX valid when unsupported formulas fall back to plain text', async () => {
+    const description =
+      '<p>Formel: ' +
+      '<span class="iqb-math-formula" data-latex="\\text{AT&T}">' +
+      '<span><math></math></span>' +
+      '</span>' +
+      '</p>';
+
+    const documentXml = await getDocumentXml(description);
+
+    expect(() => create(documentXml)).not.toThrow();
+    expect(documentXml).not.toContain('<undefined>');
+    expect(documentXml).toContain('AT&amp;T');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize OMML text-node content before embedding formula XML in DOCX
- prevent invalid XML characters (e.g. `<`, `&`) from corrupting generated Word files
- add regression tests for OMML sanitizing and formula-import path

## Testing
- `npx jest apps/api/src/app/classes/download-docx.class.spec.ts --config=apps/api/jest.config.ts --runInBand`

Closes #1421
