### PR TITLE
Kodierbericht: Variablentyp anzeigen

### DIFF
--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -336,6 +336,24 @@ describe('WorkspaceService', () => {
     });
   });
 
+  describe('determineVariableType', () => {
+    it('maps base variables to Basisvariable', () => {
+      const variableType = WorkspaceService.determineVariableType({
+        sourceType: 'BASE'
+      } as unknown as VariableCodingData);
+
+      expect(variableType).toBe('Basisvariable');
+    });
+
+    it('maps derived variables to abgeleitete Variable', () => {
+      const variableType = WorkspaceService.determineVariableType({
+        sourceType: 'SUM_SCORE'
+      } as unknown as VariableCodingData);
+
+      expect(variableType).toBe('abgeleitete Variable');
+    });
+  });
+
   describe('determineTrainingEffort', () => {
     it('returns erhöht when CODER_TRAINING_REQUIRED is set', () => {
       const trainingEffort = WorkspaceService.determineTrainingEffort({

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -415,6 +415,7 @@ export class WorkspaceService {
         unitDataRows.push({
           unit: WorkspaceService.generateUnitLink(workspaceId, unit),
           variable: codingVariable.alias || codingVariable.id || '–',
+          variableType: WorkspaceService.determineVariableType(codingVariable),
           item: foundItem?.id || '–',
           validation: validationResultText,
           codingType: codingType,
@@ -463,6 +464,12 @@ export class WorkspaceService {
     return 'keine Regeln';
   }
 
+  static determineVariableType(codingVariable: VariableCodingData): string {
+    return codingVariable.sourceType === 'BASE' ?
+      'Basisvariable' :
+      'abgeleitete Variable';
+  }
+
   static determineTrainingEffort(codingVariable: VariableCodingData): string {
     return codingVariable.processing?.includes('CODER_TRAINING_REQUIRED') ?
       'erhöht' :
@@ -495,6 +502,7 @@ export class WorkspaceService {
     unitDataRows.push({
       unit: WorkspaceService.generateUnitLink(id, unit),
       variable: '',
+      variableType: '',
       item: '',
       validation: 'Kodierschema mit Schemer Version ab 1.5 erzeugen!',
       codingType: '',

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
@@ -21,6 +21,7 @@ describe('CodingReportComponent', () => {
     {
       unit: 'U1',
       variable: 'V1',
+      variableType: 'Basisvariable',
       item: 'I1',
       validation: 'ok',
       codingType: 'keine Regeln',
@@ -29,6 +30,7 @@ describe('CodingReportComponent', () => {
     {
       unit: 'U1',
       variable: 'V2',
+      variableType: 'abgeleitete Variable',
       item: 'I2',
       validation: 'ok',
       codingType: 'REGEL',
@@ -94,7 +96,20 @@ describe('CodingReportComponent', () => {
   });
 
   it('downloadCodingReport creates and revokes object URL', () => {
-    const createObjectURLMock = jest.fn(() => 'blob:test-url');
+    const blobParts: BlobPart[][] = [];
+    const OriginalBlob = globalThis.Blob;
+    const blobMock = jest.fn((parts: BlobPart[] = [], options?: BlobPropertyBag) => {
+      blobParts.push(parts);
+      return new OriginalBlob(parts, options);
+    });
+    Object.defineProperty(globalThis, 'Blob', {
+      value: blobMock,
+      writable: true
+    });
+    const createObjectURLMock = jest.fn((blob: Blob) => {
+      expect(blob).toBeInstanceOf(OriginalBlob);
+      return 'blob:test-url';
+    });
     const revokeObjectURLMock = jest.fn();
     Object.defineProperty(URL, 'createObjectURL', {
       value: createObjectURLMock,
@@ -116,7 +131,15 @@ describe('CodingReportComponent', () => {
     expect(createObjectURLMock).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();
     expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:test-url');
+    expect(String(blobParts[0][0])).toContain(
+      'Aufgabe;Variable;Variablentyp;Item;Validierung;Kodiertyp;Schulungsaufwand'
+    );
+    expect(String(blobParts[0][0])).toContain('"abgeleitete Variable"');
 
+    Object.defineProperty(globalThis, 'Blob', {
+      value: OriginalBlob,
+      writable: true
+    });
     createElementSpy.mockRestore();
   });
 });

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -41,6 +41,7 @@ export class CodingReportComponent implements OnInit {
   displayedColumns: string[] = [
     'unit',
     'variable',
+    'variableType',
     'item',
     'validation',
     'codingType',
@@ -166,6 +167,7 @@ export class CodingReportComponent implements OnInit {
     const headers: Record<keyof CodingReportDto, string> = {
       unit: 'Aufgabe',
       variable: 'Variable',
+      variableType: 'Variablentyp',
       item: 'Item',
       validation: 'Validierung',
       codingType: 'Kodiertyp',

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -803,6 +803,7 @@
   "coding-report": {
     "unit": "Aufgabe",
     "variable": "Variable",
+    "variableType": "Variablentyp",
     "item": "Item",
     "validation": "Validierung",
     "codingType": "Kodiertyp",

--- a/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
+++ b/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
@@ -8,6 +8,9 @@ export class CodingReportDto {
     variable!: string;
 
   @ApiProperty()
+    variableType!: string;
+
+  @ApiProperty()
     item!: string;
 
   @ApiProperty()


### PR DESCRIPTION
## Summary

- ergänzt im Kodierbericht die Spalte `Variablentyp`
- leitet den Wert im Backend aus `sourceType` ab (`BASE` -> `Basisvariable`, sonst `abgeleitete Variable`)
- nimmt die neue Spalte in Tabellenanzeige, Übersetzung und CSV-Export auf

## Tests

- `npx nx test api --testFile=apps/api/src/app/services/workspace.service.spec.ts --runInBand`
- `npx nx test frontend --testFile=apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts --runInBand`
- `npx nx lint api`
- `npx nx lint frontend`

Closes #1440
