### PR TITLE
Fix filtered unit master selection

### DIFF
--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.html
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.html
@@ -29,8 +29,8 @@
     <ng-container matColumnDef="selectCheckbox">
       <mat-header-cell *matHeaderCellDef  class="fx-flex-row-fix-70">
         <mat-checkbox (change)="$event ? masterToggle() : null"
-                      [checked]="(tableSelectionCheckboxes | hasSelectionValue : tableSelectionCheckboxes.selected.length) &&  (tableSelectionCheckboxes.selected.length | isAllSelected : objectsDatasource.data.length)"
-                      [indeterminate]="(tableSelectionCheckboxes | hasSelectionValue : tableSelectionCheckboxes.selected.length) && !(tableSelectionCheckboxes.selected.length | isAllSelected : objectsDatasource.data.length)">
+                      [checked]="isAllVisibleRowsSelected"
+                      [indeterminate]="visibleSelectionCount > 0 && !isAllVisibleRowsSelected">
         </mat-checkbox>
       </mat-header-cell>
       <mat-cell *matCellDef="let row" class="fx-flex-row-fix-70">

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
@@ -26,13 +26,13 @@ describe('SelectUnitListComponent', () => {
 
   const createUnits = (): UnitInListDto[] => ([
     {
-      id: 1, key: 'U1', name: 'Unit 1', groupName: 'G1'
+      id: 1, key: 'U1', name: 'Unit 1', groupName: 'GruA'
     },
     {
-      id: 2, key: 'U2', name: 'Unit 2', groupName: 'G1'
+      id: 2, key: 'U2', name: 'Unit 2', groupName: 'GruA'
     },
     {
-      id: 3, key: 'U3', name: 'Unit 3', groupName: 'G2'
+      id: 3, key: 'U3', name: 'Unit 3', groupName: 'GruB'
     }
   ]);
 
@@ -122,12 +122,26 @@ describe('SelectUnitListComponent', () => {
   it('should toggle master selection only for filtered rows', () => {
     component.queryParams = new HttpParams();
     component.updateUnitList(10);
-    component.objectsDatasource.filter = 'g1';
+    component.objectsDatasource.filter = 'grua';
 
     component.masterToggle();
     expect(component.selectedUnitIds).toEqual([1, 2]);
 
     component.masterToggle();
     expect(component.selectedUnitIds).toEqual([]);
+  });
+
+  it('should not keep hidden selections when filter narrows after master selection', () => {
+    component.queryParams = new HttpParams();
+    component.updateUnitList(10);
+    component.objectsDatasource.filter = 'gru';
+    component.masterToggle();
+    expect(component.selectedUnitIds).toEqual([1, 2, 3]);
+
+    component.objectsDatasource.filter = 'grua';
+    component.masterToggle();
+    component.masterToggle();
+
+    expect(component.selectedUnitIds).toEqual([1, 2]);
   });
 });

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
@@ -144,4 +144,17 @@ describe('SelectUnitListComponent', () => {
 
     expect(component.selectedUnitIds).toEqual([1, 2]);
   });
+
+  it('should keep previous hidden selections when selecting another filtered row set', () => {
+    component.queryParams = new HttpParams();
+    component.updateUnitList(10);
+    component.objectsDatasource.filter = 'grua';
+    component.masterToggle();
+    expect(component.selectedUnitIds).toEqual([1, 2]);
+
+    component.objectsDatasource.filter = 'grub';
+    component.masterToggle();
+
+    expect(component.selectedUnitIds).toEqual([1, 2, 3]);
+  });
 });

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts
@@ -118,4 +118,16 @@ describe('SelectUnitListComponent', () => {
 
     expect(component.selectedUnitIds).toEqual([1, 3]);
   });
+
+  it('should toggle master selection only for filtered rows', () => {
+    component.queryParams = new HttpParams();
+    component.updateUnitList(10);
+    component.objectsDatasource.filter = 'g1';
+
+    component.masterToggle();
+    expect(component.selectedUnitIds).toEqual([1, 2]);
+
+    component.masterToggle();
+    expect(component.selectedUnitIds).toEqual([]);
+  });
 });

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
@@ -14,8 +14,6 @@ import { MatCheckbox } from '@angular/material/checkbox';
 
 import { HttpParams } from '@angular/common/http';
 import { WorkspaceBackendService } from '../../services/workspace-backend.service';
-import { HasSelectionValuePipe } from '../../../../pipes/has-selection-value.pipe';
-import { IsAllSelectedPipe } from '../../../../pipes/is-all-selected.pipe';
 import { IsSelectedPipe } from '../../../../pipes/is-selected.pipe';
 import { IncludePipe } from '../../../../pipes/include.pipe';
 import { SearchFilterComponent } from '../../../../components/search-filter/search-filter.component';
@@ -26,7 +24,7 @@ import { ScrollIntoViewDirective } from '../../directives/scroll-into-view.direc
   templateUrl: './select-unit-list.component.html',
   styleUrls: ['select-unit-list.component.scss'],
   // eslint-disable-next-line max-len
-  imports: [SearchFilterComponent, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, IncludePipe, IsSelectedPipe, IsAllSelectedPipe, HasSelectionValuePipe, TranslateModule, ScrollIntoViewDirective]
+  imports: [SearchFilterComponent, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, IncludePipe, IsSelectedPipe, TranslateModule, ScrollIntoViewDirective]
 })
 export class SelectUnitListComponent implements OnChanges, OnDestroy {
   objectsDatasource = new MatTableDataSource<UnitInListDto>();
@@ -105,6 +103,16 @@ export class SelectUnitListComponent implements OnChanges, OnDestroy {
     return this.tableSelectionCheckboxes.selected.length;
   }
 
+  get visibleSelectionCount(): number {
+    return this.visibleRows
+      .filter(row => this.tableSelectionCheckboxes.isSelected(row))
+      .length;
+  }
+
+  get isAllVisibleRowsSelected(): boolean {
+    return !!this.visibleRows.length && this.visibleSelectionCount === this.visibleRows.length;
+  }
+
   get selectedUnitIds(): number[] {
     return this.tableSelectionCheckboxes.selected.map(ud => ud.id);
   }
@@ -141,16 +149,16 @@ export class SelectUnitListComponent implements OnChanges, OnDestroy {
       .subscribe(() => this.selectionChanged.emit(this.selectedUnitIds));
   }
 
-  private isAllSelected(): boolean {
-    const numSelected = this.tableSelectionCheckboxes.selected.length;
-    const numRows = this.objectsDatasource ? this.objectsDatasource.data.length : 0;
-    return numSelected === numRows;
+  private get visibleRows(): UnitInListDto[] {
+    return this.objectsDatasource ? this.objectsDatasource.filteredData : [];
   }
 
   masterToggle(): void {
-    this.isAllSelected() || !this.objectsDatasource ?
-      this.tableSelectionCheckboxes.clear() :
-      this.objectsDatasource.data.forEach(row => this.tableSelectionCheckboxes.select(row));
+    if (this.isAllVisibleRowsSelected) {
+      this.visibleRows.forEach(row => this.tableSelectionCheckboxes.deselect(row));
+    } else {
+      this.visibleRows.forEach(row => this.tableSelectionCheckboxes.select(row));
+    }
   }
 
   ngOnDestroy(): void {

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
@@ -154,10 +154,11 @@ export class SelectUnitListComponent implements OnChanges, OnDestroy {
   }
 
   masterToggle(): void {
-    const shouldSelectVisibleRows = !this.isAllVisibleRowsSelected;
-
-    this.tableSelectionCheckboxes.clear();
-    if (shouldSelectVisibleRows) this.visibleRows.forEach(row => this.tableSelectionCheckboxes.select(row));
+    if (this.isAllVisibleRowsSelected) {
+      this.tableSelectionCheckboxes.clear();
+    } else {
+      this.visibleRows.forEach(row => this.tableSelectionCheckboxes.select(row));
+    }
   }
 
   ngOnDestroy(): void {

--- a/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.ts
@@ -154,11 +154,10 @@ export class SelectUnitListComponent implements OnChanges, OnDestroy {
   }
 
   masterToggle(): void {
-    if (this.isAllVisibleRowsSelected) {
-      this.visibleRows.forEach(row => this.tableSelectionCheckboxes.deselect(row));
-    } else {
-      this.visibleRows.forEach(row => this.tableSelectionCheckboxes.select(row));
-    }
+    const shouldSelectVisibleRows = !this.isAllVisibleRowsSelected;
+
+    this.tableSelectionCheckboxes.clear();
+    if (shouldSelectVisibleRows) this.visibleRows.forEach(row => this.tableSelectionCheckboxes.select(row));
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary

Fixes the unit selection table header checkbox so selecting all after a search/filter only affects the currently visible filtered rows. It also prevents previously selected hidden rows from being carried over when the filter is narrowed and the header checkbox is used to clear and reselect.

## Root Cause

`SelectUnitListComponent.masterToggle()` and the header checkbox state used `objectsDatasource.data`, which contains all loaded rows. Angular Material renders `objectsDatasource.filteredData` after a text filter, so hidden rows were still selected by the master checkbox.

A follow-up edge case appeared when a broad filter selection was narrowed: hidden rows selected by the previous master-toggle action could remain in `selectedUnitIds` after clearing and reselecting the narrowed filter.

## Changes

- Base the header checkbox checked/indeterminate state on visible filtered rows.
- Make `masterToggle()` add visible filtered rows when selecting, and clear the selection when all visible rows are already selected.
- Add regression tests for filtering by group, narrowing a filter after master selection, and preserving intentional selections across different filters.

Closes #1470

## Validation

- `npx nx test frontend --testFile=apps/frontend/src/app/modules/workspace/components/select-unit-list/select-unit-list.component.spec.ts --runInBand`