### PR TITLE
Resolve backend startup crash due to path-to-regexp override conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29745,12 +29745,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -118,9 +118,6 @@
   "overrides": {
     "stylus": "0.0.1-security",
     "@parcel/watcher": "2.5.1",
-    "express": {
-      "path-to-regexp": "^0.1.13"
-    },
     "@nestjs/platform-express": {
       "path-to-regexp": "^8.4.2"
     },


### PR DESCRIPTION
- Remove redundant `express` path-to-regexp override in package.json.
- Prevent forcing path-to-regexp@0.1.13 onto express@5 (used transitively by NestJS 11 platform-express).
- Restore path-to-regexp@8.x for express@5's router, resolving the TypeError "pathRegexp.match is not a function" on startup.