### PR TITLE
Preserve comment read status on unit copy and import

### DIFF
--- a/apps/api/src/app/services/unit-user.service.spec.ts
+++ b/apps/api/src/app/services/unit-user.service.spec.ts
@@ -1,12 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UpdateUnitUserDto, UnitCommentDto } from '@studio-lite-lib/api-dto';
+import { UpdateUnitUserDto } from '@studio-lite-lib/api-dto';
 import { createMock } from '@golevelup/ts-jest';
 import { UnitUserService } from './unit-user.service';
 import UnitUser from '../entities/unit-user.entity';
 import Unit from '../entities/unit.entity';
-import { UnitCommentService } from './unit-comment.service';
 
 describe('UnitUserService', () => {
   let service: UnitUserService;
@@ -15,7 +14,6 @@ describe('UnitUserService', () => {
 
   const mockUnitUserRepository = createMock<Repository<UnitUser>>();
   const mockUnitRepository = createMock<Repository<Unit>>();
-  const mockUnitCommentService = createMock<UnitCommentService>();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,10 +26,6 @@ describe('UnitUserService', () => {
         {
           provide: getRepositoryToken(Unit),
           useValue: mockUnitRepository
-        },
-        {
-          provide: UnitCommentService,
-          useValue: mockUnitCommentService
         }
       ]
     }).compile();
@@ -50,40 +44,37 @@ describe('UnitUserService', () => {
   });
 
   describe('createUnitUser', () => {
-    it('should create and save a unit user with latest comment timestamp', async () => {
+    it('should create and save a unit user with default timestamp (July 2022) when none is specified', async () => {
       const userId = 1;
       const unitId = 2;
-      const date = new Date();
-      const createdEntity = { userId, unitId, lastSeenCommentChangedAt: date } as UnitUser;
+      const createdEntity = { userId, unitId, lastSeenCommentChangedAt: new Date(2022, 6) } as UnitUser;
 
-      mockUnitCommentService.findOnesLastChangedComment.mockResolvedValue(
-        { changedAt: date } as UnitCommentDto
-      );
       (mockUnitUserRepository.create as jest.Mock).mockReturnValue(createdEntity);
       mockUnitUserRepository.save.mockResolvedValue(createdEntity);
 
       await service.createUnitUser(userId, unitId);
 
-      expect(mockUnitCommentService.findOnesLastChangedComment).toHaveBeenCalledWith(unitId);
       expect(unitUserRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({ userId, unitId, lastSeenCommentChangedAt: date })
+        expect.objectContaining({ userId, unitId, lastSeenCommentChangedAt: new Date(2022, 6) })
       );
       expect(unitUserRepository.save).toHaveBeenCalledWith(createdEntity);
     });
 
-    it('should create and save a unit user with current timestamp if no comments', async () => {
+    it('should create and save a unit user with the specified timestamp', async () => {
       const userId = 1;
       const unitId = 2;
+      const date = new Date(2025, 5);
+      const createdEntity = { userId, unitId, lastSeenCommentChangedAt: date } as UnitUser;
 
-      mockUnitCommentService.findOnesLastChangedComment.mockResolvedValue(null);
-      (mockUnitUserRepository.create as jest.Mock).mockReturnValue({} as UnitUser);
-      mockUnitUserRepository.save.mockResolvedValue({} as UnitUser);
+      (mockUnitUserRepository.create as jest.Mock).mockReturnValue(createdEntity);
+      mockUnitUserRepository.save.mockResolvedValue(createdEntity);
 
-      await service.createUnitUser(userId, unitId);
+      await service.createUnitUser(userId, unitId, date);
 
-      expect(mockUnitCommentService.findOnesLastChangedComment).toHaveBeenCalledWith(unitId);
-      expect(unitUserRepository.create).toHaveBeenCalledWith(expect.objectContaining({ userId, unitId }));
-      expect(unitUserRepository.save).toHaveBeenCalled();
+      expect(unitUserRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId, unitId, lastSeenCommentChangedAt: date })
+      );
+      expect(unitUserRepository.save).toHaveBeenCalledWith(createdEntity);
     });
   });
 
@@ -102,15 +93,12 @@ describe('UnitUserService', () => {
       expect(result).toEqual(date);
     });
 
-    it('should return default timestamp if unit user does not exist', async () => {
+    it('should return default timestamp (July 2022) if unit user does not exist', async () => {
       mockUnitUserRepository.findOne.mockResolvedValue(null);
 
-      const before = new Date().getTime();
       const result = await service.findLastSeenCommentTimestamp(1, 2);
-      const after = new Date().getTime();
 
-      expect(result.getTime()).toBeGreaterThanOrEqual(before);
-      expect(result.getTime()).toBeLessThanOrEqual(after);
+      expect(result).toEqual(new Date(2022, 6));
     });
   });
 

--- a/apps/api/src/app/services/unit-user.service.ts
+++ b/apps/api/src/app/services/unit-user.service.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { UpdateUnitUserDto } from '@studio-lite-lib/api-dto';
 import UnitUser from '../entities/unit-user.entity';
 import Unit from '../entities/unit.entity';
-import { UnitCommentService } from './unit-comment.service';
 
 @Injectable()
 export class UnitUserService {
@@ -14,17 +13,19 @@ export class UnitUserService {
     @InjectRepository(UnitUser)
     private unitUserRepository: Repository<UnitUser>,
     @InjectRepository(Unit)
-    private unitRepository: Repository<Unit>,
-    private unitCommentService: UnitCommentService
+    private unitRepository: Repository<Unit>
   ) {}
 
-  async createUnitUser(userId: number, unitId: number): Promise<void> {
+  async createUnitUser(
+    userId: number,
+    unitId: number,
+    lastSeenCommentChangedAt: Date = new Date(2022, 6)
+  ): Promise<void> {
     this.logger.log(`Creating UnitUser with userId ${userId} & unitId ${unitId}`);
-    const latestComment = await this.unitCommentService.findOnesLastChangedComment(unitId);
     const unitUser = await this.unitUserRepository.create(<UnitUser>{
       userId: userId,
       unitId: unitId,
-      lastSeenCommentChangedAt: latestComment ? latestComment.changedAt : new Date()
+      lastSeenCommentChangedAt
     });
     await this.unitUserRepository.save(unitUser);
   }
@@ -36,7 +37,7 @@ export class UnitUserService {
         unitId: unitId
       }
     });
-    return unitUser ? unitUser.lastSeenCommentChangedAt : new Date();
+    return unitUser ? unitUser.lastSeenCommentChangedAt : new Date(2022, 6);
   }
 
   async patchUnitUserCommentsLastSeen(

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -232,11 +232,6 @@ export class UnitService {
     newUnit.groupName = unit.groupName;
     await this.unitsRepository.save(newUnit);
 
-    const workspaceUsers = await this.workspaceUserRepository
-      .find({ where: { workspaceId: workspaceId } });
-    await Promise.all(workspaceUsers.map(async workspaceUser => {
-      await this.unitUserService.createUnitUser(workspaceUser.userId, newUnit.id);
-    }));
     if (unit.createFrom) {
       const unitSourceData = await this.unitsRepository.findOne({
         where: { id: unit.createFrom },
@@ -297,6 +292,25 @@ export class UnitService {
       newUnit.lastChangedMetadataUser = await this.getDisplayNameForUser(user.id);
       await this.unitsRepository.save(newUnit);
     }
+
+    // unit_user-Einträge NACH copyComments bzw. Erstellung anlegen, damit
+    // createUnitUser die kopierten/neuen Kommentare sieht.
+    // Für den kopierenden User: lastSeenCommentChangedAt aus dem Quell-Workspace übernehmen
+    // (spiegelt sein bisheriges Icon-Verhalten). Für alle anderen: Standard aus createUnitUser.
+    const workspaceUsers = await this.workspaceUserRepository
+      .find({ where: { workspaceId: workspaceId } });
+    const initiatingUserLastSeen = unit.createFrom ?
+      await this.unitUserService.findLastSeenCommentTimestamp(user.id, unit.createFrom) :
+      undefined;
+    await Promise.all(workspaceUsers.map(async workspaceUser => {
+      if (unit.createFrom && workspaceUser.userId === user.id && initiatingUserLastSeen !== undefined) {
+        // Kopierender User: Status aus Quell-Workspace übernehmen
+        await this.unitUserService.createUnitUser(workspaceUser.userId, newUnit.id, initiatingUserLastSeen);
+      } else {
+        // Alle anderen: standardmäßig new Date(2022, 6)
+        await this.unitUserService.createUnitUser(workspaceUser.userId, newUnit.id);
+      }
+    }));
     return newUnit.id;
   }
 

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -16,7 +16,8 @@ import {
   GroupNameDto,
   RenameGroupNameDto,
   UnitFullMetadataDto,
-  ItemsMetadataValues
+  ItemsMetadataValues,
+  UnitCommentDto
 } from '@studio-lite-lib/api-dto';
 import * as AdmZip from 'adm-zip';
 import {
@@ -930,8 +931,15 @@ export class WorkspaceService {
     comments: string,
     itemUuidLookups: ItemUuidLookup[]
   ) {
+    const parsedComments: UnitCommentDto[] = JSON.parse(comments);
+    // User IDs from another instance are unreliable and could randomly collide with local IDs.
+    // We therefore set them to -1 during import to ensure comments are marked as unread for all local users.
+    const sanitizedComments = parsedComments.map(c => ({
+      ...c,
+      userId: -1
+    }));
     await this.unitCommentService.createComments(
-      JSON.parse(comments),
+      sanitizedComments,
       unitId,
       itemUuidLookups
     );


### PR DESCRIPTION
- Fix unit_user initialization order in UnitService.create to run after comments are copied
- Preserve initiating user's read status from source unit when copying a unit
- Set default comment read status to July 2022 (new Date(2022, 6)) for all other users to ensure copied comments appear as unread/new
- Map all imported comment userIds to -1 during import to prevent ID collisions with other instances and ensure comments appear as unread/new for everyone
- Fix corresponding unit tests in unit-user.service.spec.ts