### PR TITLE
Resolve settings form rendering crash and datepicker range error

### DIFF
--- a/apps/frontend/src/app/modules/admin/components/app-config/app-config.component.spec.ts
+++ b/apps/frontend/src/app/modules/admin/components/app-config/app-config.component.spec.ts
@@ -133,6 +133,27 @@ describe('AppConfigComponent', () => {
     expect(component.configForm.get('globalWarningText')?.value).toBe('Test Warning');
   });
 
+  it('should convert globalWarningExpiredDay from string to Date object', () => {
+    const stringConfig = {
+      appTitle: 'Test App',
+      introHtml: '<p>Test Intro</p>',
+      imprintHtml: '<p>Test Imprint</p>',
+      emailSubject: 'Test Email Subject',
+      emailBody: 'Test Email Body',
+      globalWarningText: 'Test Warning',
+      globalWarningExpiredDay: '2026-12-31T00:00:00.000Z',
+      globalWarningExpiredHour: 12,
+      hasUsers: true
+    };
+    readBackendService.getConfig.mockReturnValue(of(stringConfig as unknown as ConfigDto));
+    const stringFixture = TestBed.createComponent(AppConfigComponent);
+    const stringComponent = stringFixture.componentInstance;
+    stringFixture.detectChanges();
+
+    expect(stringComponent.appConfig.globalWarningExpiredDay).toBeInstanceOf(Date);
+    expect(stringComponent.configForm.get('globalWarningExpiredDay')?.value).toBeInstanceOf(Date);
+  });
+
   it('should set dataChanged flag when form values change', fakeAsync(() => {
     fixture.detectChanges();
     component.dataChanged = false;

--- a/apps/frontend/src/app/modules/admin/components/app-config/app-config.component.ts
+++ b/apps/frontend/src/app/modules/admin/components/app-config/app-config.component.ts
@@ -76,7 +76,7 @@ export class AppConfigComponent implements OnInit, OnDestroy {
         if (appConfig.imprintHtml) this.appConfig.imprintHtml = appConfig.imprintHtml;
         if (appConfig.globalWarningText) this.appConfig.globalWarningText = appConfig.globalWarningText;
         if (appConfig.globalWarningExpiredDay) {
-          this.appConfig.globalWarningExpiredDay = appConfig.globalWarningExpiredDay;
+          this.appConfig.globalWarningExpiredDay = new Date(appConfig.globalWarningExpiredDay);
         }
         if (appConfig.globalWarningExpiredHour) {
           this.appConfig.globalWarningExpiredHour = appConfig.globalWarningExpiredHour;

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -27,8 +27,9 @@ import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import {
   HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi
 } from '@angular/common/http';
-import { DateFnsAdapter } from '@angular/material-date-fns-adapter';
-import { MAT_DATE_LOCALE, DateAdapter } from '@angular/material/core';
+import { provideDateFnsAdapter } from '@angular/material-date-fns-adapter';
+import { MAT_DATE_LOCALE } from '@angular/material/core';
+import { de } from 'date-fns/locale';
 import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
@@ -100,13 +101,9 @@ bootstrapApplication(AppComponent, {
     },
     {
       provide: MAT_DATE_LOCALE,
-      useValue: 'de'
+      useValue: de
     },
-    {
-      provide: DateAdapter,
-      useClass: DateFnsAdapter,
-      useValue: [MAT_DATE_LOCALE]
-    },
+    provideDateFnsAdapter(),
     {
       provide: HTTP_INTERCEPTORS,
       useClass: AuthInterceptor,


### PR DESCRIPTION
- Configure `provideDateFnsAdapter()` in `main.ts` to properly provide `MAT_DATE_FORMATS` after the Standalone components migration.
- Provide the actual `de` locale object from `date-fns/locale` instead of the string `'de'` for `MAT_DATE_LOCALE` to prevent the "locale must contain localize property" RangeError.
- Explicitly convert `globalWarningExpiredDay` from string to a native JS `Date` object in `AppConfigComponent` to avoid TypeError inside `DateFnsAdapter`.