### PR TITLE
Provide BackendService in UnitPrintCommentsComponent

### DIFF
--- a/apps/frontend/src/app/modules/print/components/unit-print-comments/unit-print-comments.component.spec.ts
+++ b/apps/frontend/src/app/modules/print/components/unit-print-comments/unit-print-comments.component.spec.ts
@@ -42,13 +42,15 @@ describe('UnitPrintCommentsComponent', () => {
         {
           provide: 'SERVER_URL',
           useValue: environment.backendUrl
-        },
-        {
-          provide: BackendService,
-          useValue: mockBackendService
         }
       ]
-    }).compileComponents();
+    })
+      .overrideComponent(UnitPrintCommentsComponent, {
+        set: {
+          providers: [{ provide: BackendService, useValue: mockBackendService }]
+        }
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(UnitPrintCommentsComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/modules/print/components/unit-print-comments/unit-print-comments.component.ts
+++ b/apps/frontend/src/app/modules/print/components/unit-print-comments/unit-print-comments.component.ts
@@ -15,7 +15,8 @@ import { MapItemUuidsIdsPipe } from '../../../comments/pipes/map-item-uuids-ids.
   selector: 'studio-lite-unit-print-comments',
   templateUrl: './unit-print-comments.component.html',
   styleUrls: ['./unit-print-comments.component.scss'],
-  imports: [MatIcon, DatePipe, TranslateModule, SortAscendingPipe, MapItemUuidsIdsPipe]
+  imports: [MatIcon, DatePipe, TranslateModule, SortAscendingPipe, MapItemUuidsIdsPipe],
+  providers: [BackendService]
 })
 export class UnitPrintCommentsComponent implements OnChanges, OnDestroy {
   @Input() unitId!: number;


### PR DESCRIPTION
  After the NgModule-to-standalone migration, BackendService (comments)lost its provider. Add it to the component's providers array since it
  lacks providedIn: 'root'.