### PR TITLE
Update @iqb/responses to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@golevelup/ts-jest": "^0.3.4",
         "@iqb/metadata": "^1.4.1",
         "@iqb/ngx-coding-components": "3.1.0",
-        "@iqb/responses": "5.0.0",
+        "@iqb/responses": "5.2.0",
         "@iqb/validate-md-profile": "^0.10.0",
         "@iqbspecs/coding-scheme": "3.3.1",
         "@iqbspecs/response": "1.4.0",
@@ -5626,9 +5626,9 @@
       }
     },
     "node_modules/@iqb/responses": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.0.0.tgz",
-      "integrity": "sha512-qqqzvhhnabBIHFZaIgvidV2r9OTlUg+oKTSAw9HzoTMOzd7bqK9aNXQArUar/LgJUQ5GiiwS3I7XWhdqXplCXg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.2.0.tgz",
+      "integrity": "sha512-Pk1s0CFA/SeAdns/RdHEKMSt/WhHYRzM7jkU7p5n/Nt+1Hpwj4zkvS8uXfofNplYhV7lkeMes1kcceqqQ2fekw==",
       "license": "CC0 1.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@angular/router": "20.3.25",
     "@golevelup/ts-jest": "^0.3.4",
     "@iqb/metadata": "^1.4.1",
-    "@iqb/responses": "5.0.0",
+    "@iqb/responses": "5.2.0",
     "@iqb/validate-md-profile": "^0.10.0",
     "@iqb/ngx-coding-components": "3.1.0",
     "@iqbspecs/response": "1.4.0",


### PR DESCRIPTION
## Summary
- Update `@iqb/responses` from `5.0.0` to `5.2.0`.
- Refresh the corresponding `package-lock.json` entry with the 5.2.0 tarball and integrity.

## Context
Requested from the discussion in https://github.com/iqb-berlin/studio-lite/issues/1490#issuecomment-4830251760 for the upcoming Studio release.

## Validation
- `npm ci --ignore-scripts`
- `npm run build-app`

Build completed successfully. The build still reports existing bundle budget, CommonJS, and missing font stylesheet warnings.
