### PR TITLE
Ignore the npm cache and the e2e coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Caches
 .angular
 .nx
+/.npm
 /.sass-cache
 
 # secret files
@@ -62,6 +63,7 @@ config/frontend/default.conf.template.bkp
 # Frontend-e2e files
 apps/frontend-e2e/cypress/downloads
 apps/frontend-e2e/cypress/coverage
+apps/frontend-e2e/coverage
 apps/frontend-e2e/.nyc_output
 
 # misc


### PR DESCRIPTION
## Summary

Adds two generated directories to `.gitignore`:

- `/.npm` — the npm cache, populated by the CI via `npm ci --cache .npm`. At 353 MB locally it is an easy way to bloat a commit with a stray `git add -A`.
- `apps/frontend-e2e/coverage` — istanbul output (`lcov.info`, `clover.xml`, `coverage-final.json`, `lcov-report/`).

## Why the existing entries don't cover this

`.gitignore` already has `/coverage`, but the leading slash anchors it to the repo root. It also has `apps/frontend-e2e/cypress/coverage`, which is a sibling path — the e2e run writes one level up, to `apps/frontend-e2e/coverage`.

## Verification

- `git check-ignore -v` matches both paths against the new rules.
- Both directories disappear from `git status`.
- Piping `git ls-files` through `git check-ignore --stdin` confirms no already-tracked file becomes ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)