### PR TITLE
Await review unit persistence in the review PATCH

### DIFF
--- a/apps/api/src/app/services/review.service.spec.ts
+++ b/apps/api/src/app/services/review.service.spec.ts
@@ -168,6 +168,44 @@ describe('ReviewService', () => {
       expect(reviewUnitRepository.create).toHaveBeenCalled();
       expect(reviewUnitRepository.save).toHaveBeenCalled();
     });
+
+    it('should replace the units with their list order in one save', async () => {
+      const review = { id: 1, name: 'old' } as Review;
+      reviewRepository.findOne.mockResolvedValue(review);
+      reviewUnitRepository.create.mockImplementation(entity => entity as ReviewUnit);
+
+      await service.patch(1, { id: 1, name: 'new', units: [30, 10, 20] } as ReviewFullDto);
+
+      expect(reviewUnitRepository.save).toHaveBeenCalledWith([
+        { reviewId: 1, unitId: 30, order: 0 },
+        { reviewId: 1, unitId: 10, order: 1 },
+        { reviewId: 1, unitId: 20, order: 2 }
+      ]);
+    });
+
+    it('should not resolve before the review units are persisted', async () => {
+      const review = { id: 1, name: 'old' } as Review;
+      reviewRepository.findOne.mockResolvedValue(review);
+      let unitsPersisted = false;
+      reviewUnitRepository.save.mockImplementation(async entity => {
+        await new Promise(resolve => { setTimeout(resolve, 0); });
+        unitsPersisted = true;
+        return entity as ReviewUnit;
+      });
+
+      await service.patch(1, { id: 1, name: 'new', units: [10, 20] } as ReviewFullDto);
+
+      expect(unitsPersisted).toBe(true);
+    });
+
+    it('should reject when persisting the review units fails', async () => {
+      const review = { id: 1, name: 'old' } as Review;
+      reviewRepository.findOne.mockResolvedValue(review);
+      reviewUnitRepository.save.mockRejectedValue(new Error('insert failed'));
+
+      await expect(service.patch(1, { id: 1, name: 'new', units: [10] } as ReviewFullDto))
+        .rejects.toThrow('insert failed');
+    });
   });
 
   describe('remove', () => {

--- a/apps/api/src/app/services/review.service.ts
+++ b/apps/api/src/app/services/review.service.ts
@@ -169,14 +169,15 @@ export class ReviewService {
     if (Object.prototype.hasOwnProperty.call(newData, 'units')) {
       await this.reviewUnitRepository.delete({ reviewId: reviewId });
       this.logger.log(`Set units for review with id: ${reviewId}`);
-      newData.units.forEach(unitId => {
-        const newReviewUnit = this.reviewUnitRepository.create({
-          reviewId: reviewId,
-          unitId: unitId,
-          order: newData.units.indexOf(unitId)
-        });
-        this.reviewUnitRepository.save(newReviewUnit);
-      });
+      const newReviewUnits = newData.units.map((unitId, index) => this.reviewUnitRepository.create({
+        reviewId: reviewId,
+        unitId: unitId,
+        order: index
+      }));
+      // Await the inserts: responding before they are written lets clients
+      // re-read the review without its new units, and insert errors would
+      // otherwise be swallowed after a 200.
+      await this.reviewUnitRepository.save(newReviewUnits);
     }
   }
 

--- a/apps/frontend-e2e/src/e2e/ui/workspace/reviews.cy.ts
+++ b/apps/frontend-e2e/src/e2e/ui/workspace/reviews.cy.ts
@@ -145,7 +145,7 @@ describe('Unit Reviews', () => {
     modifyReviewUnits(review, ['M6_AK0013']);
   });
 
-  it.skip('reflects the updated unit count when the review is opened', () => {
+  it('reflects the updated unit count when the review is opened', () => {
     cy.intercept('GET', '/api/reviews/*').as('getReview');
     cy.visit('/');
     openReview(review);


### PR DESCRIPTION
Fixes #1522

## Problem

`ReviewService.patch` feuerte pro Unit ein **nicht awaited** `reviewUnitRepository.save` in einem `forEach`:

- Der PATCH antwortete mit 200, bevor die `review_unit`-Zeilen geschrieben waren — ein direkt folgendes GET konnte das Review ohne die neuen Units sehen (Ursache des Flakes im Review-Player nach Änderung der Unit-Auswahl).
- Insert-Fehler wurden zu unhandled promise rejections statt zu einer Fehlerantwort (reproduzierbar: mit `mockRejectedValue` crashte die alte Implementierung die Test-Suite).
- Nebenbefund: `order: newData.units.indexOf(unitId)` vergibt bei doppelten Unit-IDs zweimal denselben Index.

## Fix

Die Zeilen werden per `map` (Index = `order`) gebaut und mit **einem awaited** `save(entities[])` persistiert. Der PATCH antwortet erst nach erfolgreichem Schreiben; Fehler propagieren als Fehlerantwort.

## Tests

- Neue Unit-Tests fixieren das Batch-Payload samt Reihenfolge, das Warten auf die Persistierung und die Fehler-Propagation. Gegenprobe: Am alten Code schlagen sie fehl (Suite crasht an der unhandled rejection).
- Der seit langem geskippte e2e-Test `reflects the updated unit count when the review is opened` ist **reaktiviert** und besteht; `reviews.cy.ts` läuft komplett grün (17/17, lokal gegen develop + Fix).
- Alle API-Unit-Tests grün (96 Suiten / 582 Tests), Lint sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
