### PR TITLE
Let anonymous review sessions pass the review route guard

### DIFF
--- a/apps/frontend-e2e/src/e2e/ui/workspace/reviews.cy.ts
+++ b/apps/frontend-e2e/src/e2e/ui/workspace/reviews.cy.ts
@@ -287,6 +287,61 @@ describe('Unit Reviews', () => {
     });
   });
 
+  it('grants anonymous access to a password-protected review link', () => {
+    loginWithUser(Cypress.expose('username'), Cypress.expose('password'));
+    cy.visitWs(ws1);
+    goToReviewAdmin();
+    cy.intercept('GET', '/api/workspaces/*/reviews/*').as('getReviewData');
+    cy.contains('mat-row', review).click();
+    cy.wait('@getReviewData').then(interception => {
+      const reviewLink = interception.response?.body.link;
+
+      // set a password for the review; wait until the async review data
+      // arrived and the config form re-rendered, otherwise typing races
+      // against the form being replaced
+      cy.translate(Cypress.expose('locale')).then(json => {
+        cy.get(`input[placeholder="${json.workspace['review-password']}"]`).should('be.visible');
+        cy.wait(300);
+        cy.get(`input[placeholder="${json.workspace['review-password']}"]`).clear();
+        cy.get(`input[placeholder="${json.workspace['review-password']}"]`).type('rev-1234');
+        cy.get('studio-lite-save-changes').within(() => {
+          cy.get('button').contains(json.workspace.save).click();
+        });
+        cy.get('[data-cy="workspace-review-close"]').click();
+        logout();
+
+        // open the shared link as anonymous visitor and log in with the
+        // password; wait out the initial re-renders (logout response and
+        // config load replace the input right after page load)
+        cy.visit(`/#/${reviewLink}`);
+        cy.get('[data-cy="home-password"]').should('be.visible');
+        cy.wait(500);
+        cy.get('[data-cy="home-password"]').type('rev-1234');
+        cy.clickButtonWithResponseCheck(
+          json.home.login,
+          [201],
+          '/api/login',
+          'POST',
+          'responseReviewLogin'
+        );
+      });
+
+      // the review must open and its units must be playable
+      openReview(review);
+      cy.get('.start-data').should('exist');
+      startReview();
+      cy.url().should('include', '/u/0');
+
+      // drop the anonymous review session so subsequent tests find the
+      // regular logged-in state they expect
+      cy.window().then(win => {
+        win.localStorage.removeItem('id_token');
+        win.localStorage.removeItem('refresh_token');
+      });
+      login(Cypress.expose('username'), Cypress.expose('password'));
+    });
+  });
+
   it('allows an admin to permanently delete a review', () => {
     loginWithUser(Cypress.expose('username'), Cypress.expose('password'));
     cy.visitWs(ws1);

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AboutComponent } from './components/about/about.component';
 import { HomeComponent } from './components/home/home.component';
 import { authGuard } from './guards/auth.guard';
+import { reviewAuthGuard } from './guards/review-auth.guard';
 
 export const APP_ROUTES: Routes = [
   { path: 'home', component: HomeComponent },
@@ -28,7 +29,9 @@ export const APP_ROUTES: Routes = [
   },
   {
     path: 'review/:review',
-    canActivate: [authGuard],
+    // Not authGuard: password-protected review links authenticate as
+    // anonymous review sessions with userId 0 (see reviewAuthGuard).
+    canActivate: [reviewAuthGuard],
     loadChildren: () => import('./modules/review/review.routes').then(m => m.REVIEW_ROUTES)
   },
   { path: '', redirectTo: 'home', pathMatch: 'full' },

--- a/apps/frontend/src/app/guards/review-auth.guard.spec.ts
+++ b/apps/frontend/src/app/guards/review-auth.guard.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot, convertToParamMap, Router, RouterStateSnapshot, UrlTree
+} from '@angular/router';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ReviewDto } from '@studio-lite-lib/api-dto';
+import { reviewAuthGuard } from './review-auth.guard';
+import { AppService } from '../services/app.service';
+
+describe('reviewAuthGuard', () => {
+  let router: Router;
+  let authStatus$: BehaviorSubject<'pending' | 'complete'>;
+  let mockAuthData: { userId: number; reviews: ReviewDto[] };
+
+  const routeWithReview = (reviewParam: string): ActivatedRouteSnapshot => ({
+    paramMap: convertToParamMap({ review: reviewParam })
+  } as ActivatedRouteSnapshot);
+
+  const runGuard = (
+    route: ActivatedRouteSnapshot,
+    url = '/review/2/start'
+  ): Observable<boolean | UrlTree> => TestBed.runInInjectionContext(
+    () => reviewAuthGuard(route, { url } as RouterStateSnapshot)
+  ) as Observable<boolean | UrlTree>;
+
+  beforeEach(() => {
+    authStatus$ = new BehaviorSubject<'pending' | 'complete'>('complete');
+    mockAuthData = { userId: 0, reviews: [] };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AppService,
+          useValue: {
+            authInitializationStatus$: authStatus$,
+            get authData() { return mockAuthData; }
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            createUrlTree: jest.fn().mockReturnValue({} as UrlTree),
+            navigate: jest.fn()
+          }
+        }
+      ]
+    });
+
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow logged-in users', done => {
+    mockAuthData.userId = 1;
+
+    runGuard(routeWithReview('2')).subscribe(val => {
+      expect(val).toBe(true);
+      done();
+    });
+  });
+
+  it('should allow an anonymous review session for its own review', done => {
+    mockAuthData.userId = 0;
+    mockAuthData.reviews = [{ id: 2 } as ReviewDto];
+
+    runGuard(routeWithReview('2')).subscribe(val => {
+      expect(val).toBe(true);
+      done();
+    });
+  });
+
+  it('should redirect an anonymous review session requesting another review', done => {
+    mockAuthData.userId = 0;
+    mockAuthData.reviews = [{ id: 2 } as ReviewDto];
+
+    runGuard(routeWithReview('3'), '/review/3/start').subscribe(val => {
+      expect(val).not.toBe(true);
+      expect(router.createUrlTree)
+        .toHaveBeenCalledWith(['/home'], { queryParams: { redirectTo: '/review/3/start' } });
+      done();
+    });
+  });
+
+  it('should redirect unauthenticated visitors to home with redirect target', done => {
+    mockAuthData.userId = 0;
+    mockAuthData.reviews = [];
+
+    runGuard(routeWithReview('2')).subscribe(val => {
+      expect(val).not.toBe(true);
+      expect(router.createUrlTree)
+        .toHaveBeenCalledWith(['/home'], { queryParams: { redirectTo: '/review/2/start' } });
+      done();
+    });
+  });
+});

--- a/apps/frontend/src/app/guards/review-auth.guard.ts
+++ b/apps/frontend/src/app/guards/review-auth.guard.ts
@@ -1,0 +1,38 @@
+import { inject } from '@angular/core';
+import {
+  ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree
+} from '@angular/router';
+import {
+  filter, map, Observable, take
+} from 'rxjs';
+import { AppService } from '../services/app.service';
+
+// Access to a review is granted to logged-in users AND to anonymous
+// review sessions (password-protected review links): those authenticate
+// with userId 0 and carry their single review in authData.reviews, so
+// the generic authGuard's userId check must not be applied here.
+export const reviewAuthGuard = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot
+): Observable<boolean | UrlTree> => {
+  const appService = inject(AppService);
+  const router = inject(Router);
+
+  return appService.authInitializationStatus$.pipe(
+    filter(status => status === 'complete'),
+    take(1),
+    map(() => {
+      const { authData } = appService;
+      if (authData.userId > 0) {
+        return true;
+      }
+      const requestedReviewId = Number(route.paramMap.get('review'));
+      const hasReviewSession = !!requestedReviewId &&
+        !!authData.reviews?.some(review => review.id === requestedReviewId);
+      if (hasReviewSession) {
+        return true;
+      }
+      return router.createUrlTree(['/home'], { queryParams: { redirectTo: state.url } });
+    })
+  );
+};


### PR DESCRIPTION
Fixes #1515

## Problem

Passwortgeschützte Aufgabenfolge-Links funktionieren nicht mehr: Nach der Kennwort-Eingabe erscheint die Aufgabenfolge zwar auf der Startseite, beim Öffnen landet man aber auf `/#/home?redirectTo=%2Freview%2F…%2Fstart` und die Ansicht bleibt stehen (exakt die im Ticket beobachtete URL).

**Ursache:** Die Route `review/:review` steht hinter dem generischen `authGuard`, der ausschließlich `userId > 0` durchlässt. Passwort-Logins authentifizieren sich aber als **anonyme Review-Sessions** (JWT `sub=0`, `sub2=reviewId`); ihr `auth-data` liefert `userId: 0` mit der einzelnen Review in `reviews`. Der Guard leitet sie daher trotz gültigem Token nach `/home` um. Eingeloggte Studio-Nutzer passieren den Guard — deshalb funktioniert der Zugriff „von innen".

## Fix

Eigener `reviewAuthGuard` für die Review-Route:

- eingeloggte Nutzer (`userId > 0`) passieren wie bisher,
- anonyme Review-Sessions passieren, wenn die angeforderte Review-ID (`:review`-Routenparameter) in ihren `authData.reviews` enthalten ist,
- alle anderen werden wie gehabt nach `/home?redirectTo=…` umgeleitet.

## Tests

- **Unit**: neuer `review-auth.guard.spec.ts` (eingeloggt, eigene Review, fremde Review, unauthentifiziert); alle Frontend-Tests grün (261 Suiten / 1854 Tests).
- **e2e**: neuer Test `grants anonymous access to a password-protected review link` in `reviews.cy.ts` — setzt ein Review-Passwort, meldet sich abgemeldet über den geteilten Link mit Kennwort an, öffnet die Aufgabenfolge und spielt eine Unit ab. Gegen den alten Guard schlägt der Test fehl (reproduziert #1515); mit Fix läuft `reviews.cy.ts` komplett grün (18/18, lokal).
- Lint frontend + frontend-e2e grün.

## Hinweis

Der Bug ist im aktuellen Release (main) gemeldet. Entscheidung vom 12.07.2026: kein Hotfix — der Fix geht mit dem nächsten regulären Release raus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

