### PR TITLE
Print preview: show unit key; move change dates to bottom of review info panel

### DIFF
--- a/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.html
+++ b/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.html
@@ -1,0 +1,23 @@
+<table class="last-changes">
+  @if (lastChangedDefinition) {
+    <tr>
+      <td class="cell left-cell">{{'print.last-changed-definition' | translate}}</td>
+      <td class="cell">{{lastChangedDefinitionUser}}</td>
+      <td class="cell right-cell">{{lastChangedDefinition | date: 'dd.MM.yyyy HH:mm'}}</td>
+    </tr>
+  }
+  @if (lastChangedMetadata) {
+    <tr>
+      <td class="cell left-cell">{{'print.last-changed-metadata' | translate}}</td>
+      <td class="cell">{{lastChangedMetadataUser}}</td>
+      <td class="cell right-cell">{{lastChangedMetadata | date: 'dd.MM.yyyy HH:mm'}}</td>
+    </tr>
+  }
+  @if (lastChangedScheme) {
+    <tr>
+      <td class="cell left-cell">{{'print.last-changed-scheme' | translate}}</td>
+      <td class="cell">{{lastChangedSchemeUser}}</td>
+      <td class="cell right-cell">{{lastChangedScheme | date: 'dd.MM.yyyy HH:mm'}}</td>
+    </tr>
+  }
+</table>

--- a/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.scss
+++ b/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.scss
@@ -1,0 +1,16 @@
+.left-cell {
+  width: 300px;
+}
+
+.last-changes {
+  width: 100%;
+}
+
+.cell {
+  font-size: 16px;
+  padding: 5px 0;
+}
+
+.right-cell {
+  text-align: right;
+}

--- a/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.spec.ts
+++ b/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { DatePipe } from '@angular/common';
+import { UnitLastChangesComponent } from './unit-last-changes.component';
+
+describe('UnitLastChangesComponent', () => {
+  let component: UnitLastChangesComponent;
+  let fixture: ComponentFixture<UnitLastChangesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        UnitLastChangesComponent
+      ],
+      providers: [DatePipe]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UnitLastChangesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render all change dates with users', () => {
+    component.lastChangedDefinition = new Date('2024-01-22T10:00:00');
+    component.lastChangedDefinitionUser = 'John Doe';
+    component.lastChangedMetadata = new Date('2024-02-23T11:30:00');
+    component.lastChangedMetadataUser = 'Jane Doe';
+    component.lastChangedScheme = new Date('2024-03-24T12:45:00');
+    component.lastChangedSchemeUser = 'Max Mustermann';
+
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent;
+    expect(text).toContain('John Doe');
+    expect(text).toContain('22.01.2024 10:00');
+    expect(text).toContain('Jane Doe');
+    expect(text).toContain('23.02.2024 11:30');
+    expect(text).toContain('Max Mustermann');
+    expect(text).toContain('24.03.2024 12:45');
+  });
+
+  it('should render no rows when no change dates are set', () => {
+    component.lastChangedDefinition = null;
+    component.lastChangedMetadata = null;
+    component.lastChangedScheme = null;
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelectorAll('tr').length).toBe(0);
+  });
+});

--- a/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.ts
+++ b/apps/frontend/src/app/components/unit-last-changes/unit-last-changes.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'studio-lite-unit-last-changes',
+  templateUrl: './unit-last-changes.component.html',
+  styleUrls: ['./unit-last-changes.component.scss'],
+  imports: [DatePipe, TranslateModule]
+})
+export class UnitLastChangesComponent {
+  @Input() lastChangedDefinition!: Date | undefined | null;
+  @Input() lastChangedMetadata!: Date | undefined | null;
+  @Input() lastChangedScheme!: Date | undefined | null;
+  @Input() lastChangedDefinitionUser!: string | undefined | null;
+  @Input() lastChangedMetadataUser!: string | undefined | null;
+  @Input() lastChangedSchemeUser!: string | undefined | null;
+}

--- a/apps/frontend/src/app/components/unit-properties/unit-properties.component.html
+++ b/apps/frontend/src/app/components/unit-properties/unit-properties.component.html
@@ -33,27 +33,6 @@
       <td class="cell right-cell">{{transcript}}</td>
     </tr>
   }
-  @if (lastChangedDefinition) {
-    <tr>
-      <td class="cell left-cell">{{'print.last-changed-definition' | translate}}</td>
-      <td class="cell">{{lastChangedDefinitionUser}}</td>
-      <td class="cell right-cell">{{lastChangedDefinition | date: 'dd.MM.yyyy HH:mm'}}</td>
-    </tr>
-  }
-  @if (lastChangedMetadata) {
-    <tr>
-      <td class="cell left-cell">{{'print.last-changed-metadata' | translate}}</td>
-      <td class="cell">{{lastChangedMetadataUser}}</td>
-      <td class="cell right-cell">{{lastChangedMetadata | date: 'dd.MM.yyyy HH:mm'}}</td>
-    </tr>
-  }
-  @if (lastChangedScheme) {
-    <tr>
-      <td class="cell left-cell">{{'print.last-changed-scheme' | translate}}</td>
-      <td class="cell">{{lastChangedSchemeUser}}</td>
-      <td class="cell right-cell">{{lastChangedScheme | date: 'dd.MM.yyyy HH:mm'}}</td>
-    </tr>
-  }
   @if (player) {
     <tr>
       <td class="cell left-cell">{{'print.player' | translate}}</td>

--- a/apps/frontend/src/app/components/unit-properties/unit-properties.component.html
+++ b/apps/frontend/src/app/components/unit-properties/unit-properties.component.html
@@ -1,3 +1,9 @@
+@if (key) {
+  <h2 class="unit-key">{{key}}</h2>
+}
+@if (name) {
+  <h3 class="unit-name">{{name}}</h3>
+}
 <table class="metadata">
   @if (stateLabel) {
     <tr>

--- a/apps/frontend/src/app/components/unit-properties/unit-properties.component.spec.ts
+++ b/apps/frontend/src/app/components/unit-properties/unit-properties.component.spec.ts
@@ -66,6 +66,28 @@ describe('UnitPropertiesComponent', () => {
     expect(mockBackendService.getWorkspaceGroupStates).not.toHaveBeenCalled();
   });
 
+  it('should render key and name as headings', () => {
+    component.key = 'UNIT01';
+    component.name = 'Meine Aufgabe';
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.unit-key')?.textContent).toBe('UNIT01');
+    expect(compiled.querySelector('.unit-name')?.textContent).toBe('Meine Aufgabe');
+  });
+
+  it('should not render key and name headings when they are not set', () => {
+    component.key = '';
+    component.name = null;
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.unit-key')).toBeNull();
+    expect(compiled.querySelector('.unit-name')).toBeNull();
+  });
+
   it('should render all properties in the table', () => {
     component.stateLabel = 'Resolved State';
     component.groupName = 'Group A';

--- a/apps/frontend/src/app/components/unit-properties/unit-properties.component.spec.ts
+++ b/apps/frontend/src/app/components/unit-properties/unit-properties.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { DatePipe } from '@angular/common';
 import { of } from 'rxjs';
 import { SimpleChange } from '@angular/core';
 import { UnitPropertiesComponent } from './unit-properties.component';
@@ -29,8 +28,7 @@ describe('UnitPropertiesComponent', () => {
         UnitPropertiesComponent
       ],
       providers: [
-        { provide: WorkspaceBackendService, useValue: mockBackendService },
-        DatePipe
+        { provide: WorkspaceBackendService, useValue: mockBackendService }
       ]
     }).compileComponents();
 
@@ -96,8 +94,6 @@ describe('UnitPropertiesComponent', () => {
     component.player = 'Player 1.0';
     component.editor = 'Editor 1.0';
     component.schemer = 'Schemer 1.0';
-    component.lastChangedDefinition = new Date('2024-01-22T10:00:00');
-    component.lastChangedDefinitionUser = 'John Doe';
 
     fixture.detectChanges();
 
@@ -111,8 +107,5 @@ describe('UnitPropertiesComponent', () => {
     expect(text).toContain('Player 1.0');
     expect(text).toContain('Editor 1.0');
     expect(text).toContain('Schemer 1.0');
-    expect(text).toContain('John Doe');
-    // DatePipe format: dd.MM.yyyy HH:mm
-    expect(text).toContain('22.01.2024 10:00');
   });
 });

--- a/apps/frontend/src/app/components/unit-properties/unit-properties.component.ts
+++ b/apps/frontend/src/app/components/unit-properties/unit-properties.component.ts
@@ -2,7 +2,6 @@ import {
   Component, Input, OnChanges, SimpleChanges
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { DatePipe } from '@angular/common';
 import { WorkspaceBackendService } from '../../modules/workspace/services/workspace-backend.service';
 import { State } from '../../modules/admin/models/state.type';
 
@@ -10,7 +9,7 @@ import { State } from '../../modules/admin/models/state.type';
   selector: 'studio-lite-unit-properties',
   templateUrl: './unit-properties.component.html',
   styleUrls: ['./unit-properties.component.scss'],
-  imports: [DatePipe, TranslateModule]
+  imports: [TranslateModule]
 })
 export class UnitPropertiesComponent implements OnChanges {
   @Input() workspaceGroupId!: number;
@@ -24,12 +23,6 @@ export class UnitPropertiesComponent implements OnChanges {
   @Input() player!: string;
   @Input() editor!: string | undefined | null;
   @Input() schemer!: string | undefined | null;
-  @Input() lastChangedDefinition!: Date | undefined | null;
-  @Input() lastChangedMetadata!: Date | undefined | null;
-  @Input() lastChangedScheme!: Date | undefined | null;
-  @Input() lastChangedDefinitionUser!: string | undefined | null;
-  @Input() lastChangedMetadataUser!: string | undefined | null;
-  @Input() lastChangedSchemeUser!: string | undefined | null;
 
   states: State[] = [];
   stateLabel: string = '';

--- a/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.html
+++ b/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.html
@@ -18,20 +18,19 @@
     [editor] = "unitProperties && (printOptions | include : 'printProperties') ?
     unitProperties.editor : ''"
     [schemer] = "unitProperties && (printOptions | include : 'printProperties') ?
-    unitProperties.schemer : ''"
-    [lastChangedDefinition] = "unitProperties && (printOptions | include : 'printProperties' ) ?
-    unitProperties.lastChangedDefinition : null"
-    [lastChangedMetadata] = "unitProperties && (printOptions | include : 'printProperties') ?
-    unitProperties.lastChangedMetadata : null"
-    [lastChangedScheme] = "unitProperties && (printOptions | include : 'printProperties') ?
-    unitProperties.lastChangedScheme : null"
-    [lastChangedDefinitionUser] = "unitProperties && (printOptions | include : 'printProperties' ) ?
-    unitProperties.lastChangedDefinitionUser : ''"
-    [lastChangedMetadataUser] = "unitProperties && (printOptions | include : 'printProperties') ?
-    unitProperties.lastChangedMetadataUser : ''"
-    [lastChangedSchemeUser] = "unitProperties && (printOptions | include : 'printProperties') ?
-    unitProperties.lastChangedSchemeUser : ''">
+    unitProperties.schemer : ''">
   </studio-lite-unit-properties>
+
+  @if (unitProperties && (printOptions | include : 'printProperties')) {
+    <studio-lite-unit-last-changes
+      [lastChangedDefinition]="unitProperties.lastChangedDefinition"
+      [lastChangedMetadata]="unitProperties.lastChangedMetadata"
+      [lastChangedScheme]="unitProperties.lastChangedScheme"
+      [lastChangedDefinitionUser]="unitProperties.lastChangedDefinitionUser"
+      [lastChangedMetadataUser]="unitProperties.lastChangedMetadataUser"
+      [lastChangedSchemeUser]="unitProperties.lastChangedSchemeUser">
+    </studio-lite-unit-last-changes>
+  }
 
   @if ((printOptions | include : 'printMetadata')) {
     <studio-lite-print-metadata

--- a/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.spec.ts
+++ b/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.spec.ts
@@ -43,6 +43,10 @@ describe('UnitPrintLayoutComponent', () => {
     @Input() player!: string;
     @Input() editor!: string | undefined | null;
     @Input() schemer!: string | undefined | null;
+  }
+
+  @Component({ selector: 'studio-lite-unit-last-changes', template: '', standalone: false })
+  class MockUnitLastChangesComponent {
     @Input() lastChangedDefinition!: Date | undefined | null;
     @Input() lastChangedMetadata!: Date | undefined | null;
     @Input() lastChangedScheme!: Date | undefined | null;
@@ -101,6 +105,7 @@ describe('UnitPrintLayoutComponent', () => {
       declarations: [
         MockUnitPrintMetaDateComponent,
         MockUnitMetaDataComponent,
+        MockUnitLastChangesComponent,
         MockUnitPrintCommentsComponent,
         MockUnitPrintCodingComponent,
         MockUnitPrintPlayerComponent,

--- a/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.ts
+++ b/apps/frontend/src/app/modules/print/components/unit-print-layout/unit-print-layout.component.ts
@@ -18,13 +18,14 @@ import { UnitPrintCodingComponent } from '../unit-print-coding/unit-print-coding
 import { UnitPrintCommentsComponent } from '../unit-print-comments/unit-print-comments.component';
 import { PrintMetadataComponent } from '../print-metadata/print-metadata.component';
 import { UnitPropertiesComponent } from '../../../../components/unit-properties/unit-properties.component';
+import { UnitLastChangesComponent } from '../../../../components/unit-last-changes/unit-last-changes.component';
 
 @Component({
   selector: 'studio-lite-unit-print-layout',
   templateUrl: './unit-print-layout.component.html',
   styleUrls: ['./unit-print-layout.component.scss'],
   // eslint-disable-next-line max-len
-  imports: [UnitPropertiesComponent, PrintMetadataComponent, UnitPrintCommentsComponent, UnitPrintCodingComponent, UnitPrintPlayerComponent, MatFormField, MatLabel, MatInput, FormsModule, IncludePipe, TranslateModule]
+  imports: [UnitPropertiesComponent, UnitLastChangesComponent, PrintMetadataComponent, UnitPrintCommentsComponent, UnitPrintCodingComponent, UnitPrintPlayerComponent, MatFormField, MatLabel, MatInput, FormsModule, IncludePipe, TranslateModule]
 })
 export class UnitPrintLayoutComponent implements OnInit {
   @Input() unitId!: number;

--- a/apps/frontend/src/app/modules/review/components/unit-info/unit-info.component.html
+++ b/apps/frontend/src/app/modules/review/components/unit-info/unit-info.component.html
@@ -28,13 +28,7 @@
     }
     @if (reviewService.reviewConfig.showMetadata && properties) {
       <studio-lite-unit-properties
-        [description]="properties ? properties.description : null"
-        [lastChangedDefinition] = "properties ? properties.lastChangedDefinition : null"
-        [lastChangedMetadata] = "properties ? properties.lastChangedMetadata : null"
-        [lastChangedScheme] = "properties ? properties.lastChangedScheme : null"
-        [lastChangedDefinitionUser]="properties ? properties.lastChangedDefinitionUser : null"
-        [lastChangedMetadataUser]="properties ? properties.lastChangedMetadataUser : null"
-        [lastChangedSchemeUser]="properties ? properties.lastChangedSchemeUser : null">
+        [description]="properties ? properties.description : null">
       </studio-lite-unit-properties>
       <studio-lite-print-metadata
         [metadata] = "properties && properties.metadata || null">
@@ -55,6 +49,17 @@
         [reviewId]="reviewService.reviewId"
         [comments]="reviewService.allComments">
       </studio-lite-unit-print-comments>
+    }
+
+    @if (reviewService.reviewConfig.showMetadata && properties) {
+      <studio-lite-unit-last-changes
+        [lastChangedDefinition]="properties.lastChangedDefinition"
+        [lastChangedMetadata]="properties.lastChangedMetadata"
+        [lastChangedScheme]="properties.lastChangedScheme"
+        [lastChangedDefinitionUser]="properties.lastChangedDefinitionUser"
+        [lastChangedMetadataUser]="properties.lastChangedMetadataUser"
+        [lastChangedSchemeUser]="properties.lastChangedSchemeUser">
+      </studio-lite-unit-last-changes>
     }
   </div>
 </div>

--- a/apps/frontend/src/app/modules/review/components/unit-info/unit-info.component.ts
+++ b/apps/frontend/src/app/modules/review/components/unit-info/unit-info.component.ts
@@ -10,6 +10,7 @@ import { MatIcon } from '@angular/material/icon';
 import { of } from 'rxjs';
 import { ReviewService } from '../../services/review.service';
 import { UnitPropertiesComponent } from '../../../../components/unit-properties/unit-properties.component';
+import { UnitLastChangesComponent } from '../../../../components/unit-last-changes/unit-last-changes.component';
 import { WrappedIconComponent } from '../../../../components/wrapped-icon/wrapped-icon.component';
 import { PrintMetadataComponent } from '../../../print/components/print-metadata/print-metadata.component';
 import {
@@ -24,7 +25,7 @@ const PanelWidthOffset = 40;
   templateUrl: './unit-info.component.html',
   styleUrls: ['./unit-info.component.scss'],
   // eslint-disable-next-line max-len
-  imports: [MatIcon, MatButton, MatTooltip, WrappedIconComponent, UnitPropertiesComponent, TranslateModule, PrintMetadataComponent, UnitPrintCommentsComponent, UnitPrintCodingComponent]
+  imports: [MatIcon, MatButton, MatTooltip, WrappedIconComponent, UnitPropertiesComponent, UnitLastChangesComponent, TranslateModule, PrintMetadataComponent, UnitPrintCommentsComponent, UnitPrintCodingComponent]
 })
 export class UnitInfoComponent implements AfterViewInit, OnDestroy {
   @ViewChild('infoPanelSplitter') splitterElement!: ElementRef;


### PR DESCRIPTION
Closes #1484, closes #1478

## Unit key and name in print preview (#1484)
The shared `UnitPropertiesComponent` received `key` and `name` as inputs but never rendered them, so units could not be identified in the print preview. They are now rendered as headings (`h2`/`h3`), mirroring the review info panel. The review panel is unaffected since it renders its own headings and does not pass these inputs.

## Change dates at the bottom of the review info panel (#1478)
The `lastChanged*` rows are extracted from `UnitPropertiesComponent` into a new dedicated `UnitLastChangesComponent`, so each consumer places them where needed:
- **Review info panel**: change dates now appear at the very bottom (after metadata, coding and comments), still gated on `showMetadata`. Frequently used information stays at the top.
- **Print preview**: the new component sits directly below the properties table, gated on the `printProperties` option as before; change dates now appear at the end of the properties block instead of in the middle.

## Tests
- New spec for `UnitLastChangesComponent`, updated specs for `UnitPropertiesComponent` and `UnitPrintLayoutComponent` (74 tests in the affected suites pass, ESLint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)