### PR TITLE
Fix Metadaten-Eingabe: Fokusverlust pro Tastendruck (bump metadata-components 0.2.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-browser-dynamic": "20.3.25",
         "@angular/router": "20.3.25",
         "@golevelup/ts-jest": "^0.3.4",
-        "@iqb/metadata-components": "0.2.7",
+        "@iqb/metadata-components": "0.2.8",
         "@iqb/metadata-resolver": "0.2.1",
         "@iqb/ngx-coding-components": "3.1.2",
         "@iqb/responses": "5.2.0",
@@ -5743,9 +5743,9 @@
       }
     },
     "node_modules/@iqb/metadata-components": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@iqb/metadata-components/-/metadata-components-0.2.7.tgz",
-      "integrity": "sha512-fu9dCDz7NaB9H30/VURMHIQWJ50ZJEPIwzl0i1vJFH2/Pb6QS0wVNROqanPIdKseRTDse/PCQQ47Lc1tjH0Zxw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@iqb/metadata-components/-/metadata-components-0.2.8.tgz",
+      "integrity": "sha512-N36KWQ8TXajiFK4iHbWUKcM36WhaHkGYTLgEnCtJg93/tYVOF+ibf9Tx/2fLM4l8EIslBHUUD6rzzzzS7DFE0g==",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser-dynamic": "20.3.25",
     "@angular/router": "20.3.25",
     "@golevelup/ts-jest": "^0.3.4",
-    "@iqb/metadata-components": "0.2.7",
+    "@iqb/metadata-components": "0.2.8",
     "@iqb/metadata-resolver": "0.2.1",
     "@iqb/ngx-coding-components": "3.1.2",
     "@iqb/responses": "5.2.0",


### PR DESCRIPTION
## Problem
Beim Tippen in Metadaten-Feldern (Unit- und Item-Profil, alle Feldtypen) verlor das Eingabefeld nach jedem einzelnen Zeichen den Fokus, und die Seite scrollte nach oben — es ließ sich kein Wort eingeben. Aufgefallen beim manuellen Testen der über `feature/unit_index_json` (#1521) gemergten Änderungen.

## Ursache
Bug in `@iqb/metadata-components` 0.2.7 (`ProfileFormComponent`): Der Profil-Effect ruft `loadProfile()` auf, das intern `metadataSignal` und `model` liest. Angular-Effects abonnieren jedes während der Ausführung gelesene Signal, wodurch der Effect auch von `metadataSignal` abhing. `onModelChange` setzt `metadataSignal` bei jedem Tastendruck → der Effect feuerte erneut → `fields.set()` baute den kompletten Formly-Feldbaum neu auf → das getippte Input-DOM wurde ersetzt (Fokusverlust + Scroll).

Das ist ausschließlich package-intern und studio-lite-seitig nicht behebbar.

## Fix
Upstream in [iqb-berlin/metadata-components#21](https://github.com/iqb-berlin/metadata-components/pull/21) (gemerged, veröffentlicht als 0.2.8): Der metadaten-/model-abhängige Teil von `loadProfile` wird in `untracked(...)` gekapselt, sodass der Effect nur noch von `profileSignal` abhängt.

Dieser PR zieht den Fix per Version-Bump `0.2.7` → `0.2.8` ein.

## Tests
- Metadaten-Specs grün (39/39: item, items, metadata.service, table-view, unit-properties).
- Production-Build (`nx build frontend`) erfolgreich.
- Regressionstest liegt im Package (`profile-form-focus.component.spec.ts`, schlägt ohne Fix fehl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)