### PR TITLE
Fix DB-Crash beim Speichern von Metadaten (reconcile-by-profileId + Transaktion)

### DIFF
--- a/apps/api/src/app/services/unit-item-metadata.service.spec.ts
+++ b/apps/api/src/app/services/unit-item-metadata.service.spec.ts
@@ -96,7 +96,10 @@ describe('UnitItemMetadataService', () => {
 
       const result = await service.updateItemMetadata(id, dto);
 
-      expect(repository.update).toHaveBeenCalledWith(id, dto);
+      expect(repository.update).toHaveBeenCalledWith(
+        id,
+        expect.objectContaining({ profileId: 'p1', changedAt: expect.any(Date) })
+      );
       expect(result).toBe(id);
     });
   });

--- a/apps/api/src/app/services/unit-item-metadata.service.ts
+++ b/apps/api/src/app/services/unit-item-metadata.service.ts
@@ -23,13 +23,22 @@ export class UnitItemMetadataService {
   async addItemMetadata(unitItemUuid: string, metadata: UnitItemMetadataDto): Promise<number> {
     metadata.unitItemUuid = unitItemUuid;
     const { id, ...metadataWithoutId } = metadata;
-    const newItemMetadata = this.unitItemMetadataRepository.create(metadataWithoutId);
+    // created_at, changed_at and is_current are NOT NULL columns without a DB
+    // default. The client cannot supply them (the profile form re-emits without
+    // them), so they are set here — otherwise the INSERT violates NOT NULL.
+    const now = new Date();
+    const newItemMetadata = this.unitItemMetadataRepository.create({
+      ...metadataWithoutId,
+      isCurrent: metadataWithoutId.isCurrent ?? false,
+      createdAt: metadataWithoutId.createdAt ?? now,
+      changedAt: now
+    });
     await this.unitItemMetadataRepository.save(newItemMetadata);
     return newItemMetadata.id;
   }
 
   async updateItemMetadata(id: number, metadata: UnitItemMetadataDto): Promise<number> {
-    await this.unitItemMetadataRepository.update(id, metadata);
+    await this.unitItemMetadataRepository.update(id, { ...metadata, changedAt: new Date() });
     return id;
   }
 

--- a/apps/api/src/app/services/unit-item-metadata.service.ts
+++ b/apps/api/src/app/services/unit-item-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { UnitItemMetadataDto } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import UnitItemMetadata from '../entities/unit-item-metadata.entity';
 
 export class UnitItemMetadataService {
@@ -12,37 +12,43 @@ export class UnitItemMetadataService {
     private unitItemMetadataRepository: Repository<UnitItemMetadata>
   ) {}
 
+  // When a transactional manager is passed the write joins that transaction;
+  // otherwise the injected repository (default connection) is used.
+  private repo(manager?: EntityManager): Repository<UnitItemMetadata> {
+    return manager ? manager.getRepository(UnitItemMetadata) : this.unitItemMetadataRepository;
+  }
+
   async getAll(): Promise<UnitItemMetadataDto[]> {
     return this.unitItemMetadataRepository.find();
   }
 
-  async getAllByItemId(unitItemUuid: string): Promise<UnitItemMetadataDto[]> {
-    return this.unitItemMetadataRepository.findBy({ unitItemUuid: unitItemUuid });
+  async getAllByItemId(unitItemUuid: string, manager?: EntityManager): Promise<UnitItemMetadataDto[]> {
+    return this.repo(manager).findBy({ unitItemUuid: unitItemUuid });
   }
 
-  async addItemMetadata(unitItemUuid: string, metadata: UnitItemMetadataDto): Promise<number> {
+  async addItemMetadata(unitItemUuid: string, metadata: UnitItemMetadataDto, manager?: EntityManager): Promise<number> {
     metadata.unitItemUuid = unitItemUuid;
     const { id, ...metadataWithoutId } = metadata;
     // created_at, changed_at and is_current are NOT NULL columns without a DB
     // default. The client cannot supply them (the profile form re-emits without
     // them), so they are set here — otherwise the INSERT violates NOT NULL.
     const now = new Date();
-    const newItemMetadata = this.unitItemMetadataRepository.create({
+    const newItemMetadata = this.repo(manager).create({
       ...metadataWithoutId,
       isCurrent: metadataWithoutId.isCurrent ?? false,
       createdAt: metadataWithoutId.createdAt ?? now,
       changedAt: now
     });
-    await this.unitItemMetadataRepository.save(newItemMetadata);
+    await this.repo(manager).save(newItemMetadata);
     return newItemMetadata.id;
   }
 
-  async updateItemMetadata(id: number, metadata: UnitItemMetadataDto): Promise<number> {
-    await this.unitItemMetadataRepository.update(id, { ...metadata, changedAt: new Date() });
+  async updateItemMetadata(id: number, metadata: UnitItemMetadataDto, manager?: EntityManager): Promise<number> {
+    await this.repo(manager).update(id, { ...metadata, changedAt: new Date() });
     return id;
   }
 
-  async removeItemMetadata(id: number): Promise<void> {
-    await this.unitItemMetadataRepository.delete(id);
+  async removeItemMetadata(id: number, manager?: EntityManager): Promise<void> {
+    await this.repo(manager).delete(id);
   }
 }

--- a/apps/api/src/app/services/unit-item.service.spec.ts
+++ b/apps/api/src/app/services/unit-item.service.spec.ts
@@ -144,10 +144,10 @@ describe('UnitItemService', () => {
       expect(repository.update).toHaveBeenCalled();
       // p1 matches an existing row -> update it (identity kept), never re-inserted
       expect(unitItemMetadataService.updateItemMetadata)
-        .toHaveBeenCalledWith(2, expect.objectContaining({ id: 2, profileId: 'p1' }));
+        .toHaveBeenCalledWith(2, expect.objectContaining({ id: 2, profileId: 'p1' }), undefined);
       expect(unitItemMetadataService.addItemMetadata).not.toHaveBeenCalled();
       // p2 is no longer present -> removed
-      expect(unitItemMetadataService.removeItemMetadata).toHaveBeenCalledWith(3);
+      expect(unitItemMetadataService.removeItemMetadata).toHaveBeenCalledWith(3, undefined);
     });
 
     it('inserts an item profile that has no stored counterpart', async () => {
@@ -164,7 +164,7 @@ describe('UnitItemService', () => {
       await service.updateItem(uuid, inputItem);
 
       expect(unitItemMetadataService.addItemMetadata)
-        .toHaveBeenCalledWith(uuid, expect.objectContaining({ profileId: 'p-new' }));
+        .toHaveBeenCalledWith(uuid, expect.objectContaining({ profileId: 'p-new' }), undefined);
       expect(unitItemMetadataService.removeItemMetadata).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/app/services/unit-item.service.spec.ts
+++ b/apps/api/src/app/services/unit-item.service.spec.ts
@@ -121,15 +121,19 @@ describe('UnitItemService', () => {
   });
 
   describe('updateItem', () => {
-    it('should update item and sync metadata', async () => {
+    it('should sync item metadata by profileId, preserving row identity', async () => {
+      // The client re-emits profiles without their row id but keeps the profileId.
       const uuid = 'uuid-1';
       const inputItem = {
         uuid,
-        profiles: [{ id: 1, unitItemUuid: uuid }]
+        profiles: [{ profileId: 'p1', unitItemUuid: uuid }]
       } as UnitItemWithMetadataDto;
 
       const existingItem = { uuid } as UnitItem;
-      const existingProfiles = [{ id: 2, unitItemUuid: uuid }] as UnitItemMetadataDto[];
+      const existingProfiles = [
+        { id: 2, profileId: 'p1', unitItemUuid: uuid },
+        { id: 3, profileId: 'p2', unitItemUuid: uuid }
+      ] as UnitItemMetadataDto[];
 
       mockRepository.findOneBy.mockResolvedValue(existingItem);
       mockRepository.update.mockResolvedValue({ affected: 1 });
@@ -138,8 +142,30 @@ describe('UnitItemService', () => {
       await service.updateItem(uuid, inputItem);
 
       expect(repository.update).toHaveBeenCalled();
-      expect(unitItemMetadataService.removeItemMetadata).toHaveBeenCalledWith(2);
-      expect(unitItemMetadataService.updateItemMetadata).toHaveBeenCalled();
+      // p1 matches an existing row -> update it (identity kept), never re-inserted
+      expect(unitItemMetadataService.updateItemMetadata)
+        .toHaveBeenCalledWith(2, expect.objectContaining({ id: 2, profileId: 'p1' }));
+      expect(unitItemMetadataService.addItemMetadata).not.toHaveBeenCalled();
+      // p2 is no longer present -> removed
+      expect(unitItemMetadataService.removeItemMetadata).toHaveBeenCalledWith(3);
+    });
+
+    it('inserts an item profile that has no stored counterpart', async () => {
+      const uuid = 'uuid-1';
+      const inputItem = {
+        uuid,
+        profiles: [{ profileId: 'p-new', unitItemUuid: uuid }]
+      } as UnitItemWithMetadataDto;
+
+      mockRepository.findOneBy.mockResolvedValue({ uuid } as UnitItem);
+      mockRepository.update.mockResolvedValue({ affected: 1 });
+      mockUnitItemMetadataService.getAllByItemId.mockResolvedValue([]);
+
+      await service.updateItem(uuid, inputItem);
+
+      expect(unitItemMetadataService.addItemMetadata)
+        .toHaveBeenCalledWith(uuid, expect.objectContaining({ profileId: 'p-new' }));
+      expect(unitItemMetadataService.removeItemMetadata).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/app/services/unit-item.service.ts
+++ b/apps/api/src/app/services/unit-item.service.ts
@@ -3,7 +3,7 @@ import {
   UnitItemDto, UnitItemInViewDto, UnitItemMetadataDto, UnitItemWithMetadataDto
 } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import { profileIdsMatch, reconcileProfilesByProfileId } from '@studio-lite/shared-code';
 import UnitItem from '../entities/unit-item.entity';
 import { UnitItemMetadataService } from './unit-item-metadata.service';
@@ -19,6 +19,12 @@ export class UnitItemService {
     private unitItemMetadataService: UnitItemMetadataService,
     private itemCommentService: ItemCommentService
   ) {}
+
+  // When a transactional manager is passed the write joins that transaction;
+  // otherwise the injected repository (default connection) is used.
+  private repo(manager?: EntityManager): Repository<UnitItem> {
+    return manager ? manager.getRepository(UnitItem) : this.unitItemRepository;
+  }
 
   async getAll(): Promise<UnitItemDto[]> {
     return this.unitItemRepository.find();
@@ -46,21 +52,22 @@ export class UnitItemService {
 
   async getAllByUnitId(unitId: number,
                        orderKey: string = 'id',
-                       direction: 'DESC' | 'ASC' = 'ASC'): Promise<UnitItemDto[]> {
-    return this.unitItemRepository
+                       direction: 'DESC' | 'ASC' = 'ASC',
+                       manager?: EntityManager): Promise<UnitItemDto[]> {
+    return this.repo(manager)
       .find(
         { where: { unitId: unitId }, order: { [orderKey]: direction } });
   }
 
-  async getOneByUuid(uuid: string): Promise<UnitItemDto> {
-    return this.unitItemRepository.findOneBy({ uuid: uuid });
+  async getOneByUuid(uuid: string, manager?: EntityManager): Promise<UnitItemDto> {
+    return this.repo(manager).findOneBy({ uuid: uuid });
   }
 
-  async getAllByUnitIdWithMetadata(unitId: number): Promise<UnitItemWithMetadataDto[]> {
-    return Promise.all((await this.getAllByUnitId(unitId))
+  async getAllByUnitIdWithMetadata(unitId: number, manager?: EntityManager): Promise<UnitItemWithMetadataDto[]> {
+    return Promise.all((await this.getAllByUnitId(unitId, 'id', 'ASC', manager))
       .map(async item => ({
         ...item,
-        profiles: await this.unitItemMetadataService.getAllByItemId(item.uuid)
+        profiles: await this.unitItemMetadataService.getAllByItemId(item.uuid, manager)
       }))
     );
   }
@@ -78,23 +85,27 @@ export class UnitItemService {
     return { unchanged, removed, added };
   }
 
-  async updateItem(uuid: string, item: UnitItemWithMetadataDto): Promise<void> {
-    const updateItem = await this.getOneByUuid(uuid);
+  async updateItem(uuid: string, item: UnitItemWithMetadataDto, manager?: EntityManager): Promise<void> {
+    const updateItem = await this.getOneByUuid(uuid, manager);
     if (updateItem) {
       const { profiles, ...unitItem } = item;
-      await this.unitItemRepository.update(uuid, unitItem);
-      await this.reconcileItemProfiles(uuid, profiles || []);
+      await this.repo(manager).update(uuid, unitItem);
+      await this.reconcileItemProfiles(uuid, profiles || [], manager);
     }
   }
 
   // Reconcile item metadata by profileId (the profile form re-emits without the
   // row id), so an edit updates the existing row instead of delete + re-insert.
-  private async reconcileItemProfiles(uuid: string, profiles: UnitItemMetadataDto[]): Promise<void> {
-    const existingProfiles = await this.unitItemMetadataService.getAllByItemId(uuid);
+  private async reconcileItemProfiles(
+    uuid: string,
+    profiles: UnitItemMetadataDto[],
+    manager?: EntityManager
+  ): Promise<void> {
+    const existingProfiles = await this.unitItemMetadataService.getAllByItemId(uuid, manager);
     await reconcileProfilesByProfileId(existingProfiles, profiles, {
-      remove: id => this.unitItemMetadataService.removeItemMetadata(id),
-      update: (id, metadata) => this.unitItemMetadataService.updateItemMetadata(id, metadata),
-      add: metadata => this.unitItemMetadataService.addItemMetadata(uuid, metadata)
+      remove: id => this.unitItemMetadataService.removeItemMetadata(id, manager),
+      update: (id, metadata) => this.unitItemMetadataService.updateItemMetadata(id, metadata, manager),
+      add: metadata => this.unitItemMetadataService.addItemMetadata(uuid, metadata, manager)
     });
   }
 
@@ -107,21 +118,21 @@ export class UnitItemService {
     }));
   }
 
-  async addItem(unitId: number, item: UnitItemWithMetadataDto): Promise<string> {
+  async addItem(unitId: number, item: UnitItemWithMetadataDto, manager?: EntityManager): Promise<string> {
     item.unitId = unitId;
     const { uuid, ...itemWithoutUuid } = item;
-    const newItem = this.unitItemRepository.create(itemWithoutUuid);
-    await this.unitItemRepository.save(newItem);
+    const newItem = this.repo(manager).create(itemWithoutUuid);
+    await this.repo(manager).save(newItem);
     if (item.profiles) {
       await Promise.all(item.profiles
         .map(profile => this.unitItemMetadataService
-          .addItemMetadata(newItem.uuid, profile)));
+          .addItemMetadata(newItem.uuid, profile, manager)));
     }
     return newItem.uuid;
   }
 
-  async removeItem(uuid: string): Promise<void> {
-    await this.unitItemRepository.delete(uuid);
+  async removeItem(uuid: string, manager?: EntityManager): Promise<void> {
+    await this.repo(manager).delete(uuid);
   }
 
   async findItemCommentsByUnitId(unitId: number): Promise<UnitCommentUnitItem[]> {

--- a/apps/api/src/app/services/unit-item.service.ts
+++ b/apps/api/src/app/services/unit-item.service.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@nestjs/common';
-import { UnitItemDto, UnitItemInViewDto, UnitItemWithMetadataDto } from '@studio-lite-lib/api-dto';
+import {
+  MetadataDto, UnitItemDto, UnitItemInViewDto, UnitItemMetadataDto, UnitItemWithMetadataDto
+} from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { profileIdsMatch } from '@studio-lite/shared-code';
@@ -76,30 +78,53 @@ export class UnitItemService {
     return { unchanged, removed, added };
   }
 
+  // Reconcile an incoming profile with its stored row: the client cannot supply a
+  // stable row id (the profile form re-emits without it), so identity, creation
+  // time and the current-profile flag are carried over from the stored row and
+  // only the entries/values come from the incoming payload.
+  static mergeMetadata<T extends MetadataDto>(existing: T, incoming: T): T {
+    return {
+      ...existing,
+      ...incoming,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      isCurrent: incoming.isCurrent ?? existing.isCurrent
+    };
+  }
+
   async updateItem(uuid: string, item: UnitItemWithMetadataDto): Promise<void> {
     const updateItem = await this.getOneByUuid(uuid);
     if (updateItem) {
       const { profiles, ...unitItem } = item;
       await this.unitItemRepository.update(uuid, unitItem);
-      const profilesToUpdate = await this.unitItemMetadataService.getAllByItemId(item.uuid);
-      const { unchanged, removed, added } = UnitItemService.compare(profilesToUpdate, profiles, 'id');
-      unchanged
-        .map(metadata => this.unitItemMetadataService.updateItemMetadata(metadata.id, metadata));
-      removed
-        .map(metadata => this.unitItemMetadataService.removeItemMetadata(metadata.id));
-      added
-        .map(metadata => this.unitItemMetadataService.addItemMetadata(uuid, metadata));
+      await this.reconcileItemProfiles(uuid, profiles || []);
     }
   }
 
-  async patchItemMetadataCurrentProfile(unitId: number, itemProfile: string) {
+  // Match incoming profiles to stored rows by profileId (not by the missing row
+  // id), so an edit updates the existing row instead of deleting and re-inserting
+  // it — which previously dropped created_at/is_current and violated NOT NULL.
+  private async reconcileItemProfiles(uuid: string, profiles: UnitItemMetadataDto[]): Promise<void> {
+    const existingProfiles = await this.unitItemMetadataService.getAllByItemId(uuid);
+    const incomingProfileIds = new Set(profiles.map(profile => profile.profileId));
+    const removed = existingProfiles.filter(existing => !incomingProfileIds.has(existing.profileId));
+    await Promise.all(removed
+      .map(profile => this.unitItemMetadataService.removeItemMetadata(profile.id)));
+    await Promise.all(profiles.map(profile => {
+      const existing = existingProfiles.find(candidate => candidate.profileId === profile.profileId);
+      return existing ?
+        this.unitItemMetadataService.updateItemMetadata(existing.id, UnitItemService.mergeMetadata(existing, profile)) :
+        this.unitItemMetadataService.addItemMetadata(uuid, profile);
+    }));
+  }
+
+  async patchItemMetadataCurrentProfile(unitId: number, itemProfile: string): Promise<void> {
     const itemsToUpdate: UnitItemWithMetadataDto[] = await this.getAllByUnitIdWithMetadata(unitId);
     const profiles = itemsToUpdate.flatMap(metadata => metadata.profiles);
-    profiles.map(metadata => {
+    await Promise.all(profiles.map(metadata => {
       metadata.isCurrent = profileIdsMatch(metadata.profileId, itemProfile);
-      this.unitItemMetadataService.updateItemMetadata(metadata.id, metadata);
-      return metadata;
-    });
+      return this.unitItemMetadataService.updateItemMetadata(metadata.id, metadata);
+    }));
   }
 
   async addItem(unitId: number, item: UnitItemWithMetadataDto): Promise<string> {
@@ -108,9 +133,9 @@ export class UnitItemService {
     const newItem = this.unitItemRepository.create(itemWithoutUuid);
     await this.unitItemRepository.save(newItem);
     if (item.profiles) {
-      item.profiles
-        .map(async profile => this.unitItemMetadataService
-          .addItemMetadata(newItem.uuid, profile));
+      await Promise.all(item.profiles
+        .map(profile => this.unitItemMetadataService
+          .addItemMetadata(newItem.uuid, profile)));
     }
     return newItem.uuid;
   }

--- a/apps/api/src/app/services/unit-item.service.ts
+++ b/apps/api/src/app/services/unit-item.service.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@nestjs/common';
 import {
-  MetadataDto, UnitItemDto, UnitItemInViewDto, UnitItemMetadataDto, UnitItemWithMetadataDto
+  UnitItemDto, UnitItemInViewDto, UnitItemMetadataDto, UnitItemWithMetadataDto
 } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
-import { profileIdsMatch } from '@studio-lite/shared-code';
+import { profileIdsMatch, reconcileProfilesByProfileId } from '@studio-lite/shared-code';
 import UnitItem from '../entities/unit-item.entity';
 import { UnitItemMetadataService } from './unit-item-metadata.service';
 import { ItemCommentService } from './item-comment.service';
@@ -78,20 +78,6 @@ export class UnitItemService {
     return { unchanged, removed, added };
   }
 
-  // Reconcile an incoming profile with its stored row: the client cannot supply a
-  // stable row id (the profile form re-emits without it), so identity, creation
-  // time and the current-profile flag are carried over from the stored row and
-  // only the entries/values come from the incoming payload.
-  static mergeMetadata<T extends MetadataDto>(existing: T, incoming: T): T {
-    return {
-      ...existing,
-      ...incoming,
-      id: existing.id,
-      createdAt: existing.createdAt,
-      isCurrent: incoming.isCurrent ?? existing.isCurrent
-    };
-  }
-
   async updateItem(uuid: string, item: UnitItemWithMetadataDto): Promise<void> {
     const updateItem = await this.getOneByUuid(uuid);
     if (updateItem) {
@@ -101,21 +87,15 @@ export class UnitItemService {
     }
   }
 
-  // Match incoming profiles to stored rows by profileId (not by the missing row
-  // id), so an edit updates the existing row instead of deleting and re-inserting
-  // it — which previously dropped created_at/is_current and violated NOT NULL.
+  // Reconcile item metadata by profileId (the profile form re-emits without the
+  // row id), so an edit updates the existing row instead of delete + re-insert.
   private async reconcileItemProfiles(uuid: string, profiles: UnitItemMetadataDto[]): Promise<void> {
     const existingProfiles = await this.unitItemMetadataService.getAllByItemId(uuid);
-    const incomingProfileIds = new Set(profiles.map(profile => profile.profileId));
-    const removed = existingProfiles.filter(existing => !incomingProfileIds.has(existing.profileId));
-    await Promise.all(removed
-      .map(profile => this.unitItemMetadataService.removeItemMetadata(profile.id)));
-    await Promise.all(profiles.map(profile => {
-      const existing = existingProfiles.find(candidate => candidate.profileId === profile.profileId);
-      return existing ?
-        this.unitItemMetadataService.updateItemMetadata(existing.id, UnitItemService.mergeMetadata(existing, profile)) :
-        this.unitItemMetadataService.addItemMetadata(uuid, profile);
-    }));
+    await reconcileProfilesByProfileId(existingProfiles, profiles, {
+      remove: id => this.unitItemMetadataService.removeItemMetadata(id),
+      update: (id, metadata) => this.unitItemMetadataService.updateItemMetadata(id, metadata),
+      add: metadata => this.unitItemMetadataService.addItemMetadata(uuid, metadata)
+    });
   }
 
   async patchItemMetadataCurrentProfile(unitId: number, itemProfile: string): Promise<void> {

--- a/apps/api/src/app/services/unit-metadata-to-delete.service.ts
+++ b/apps/api/src/app/services/unit-metadata-to-delete.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import UnitMetadataToDelete from '../entities/unit-metadata-to-delete.entity';
 
 @Injectable()
@@ -9,8 +9,9 @@ export class UnitMetadataToDeleteService {
     @InjectRepository(UnitMetadataToDelete)
     private unitMetadataToDeleteRepository: Repository<UnitMetadataToDelete>) {}
 
-  async upsertOneForUnit(unitId: number) {
-    await this.unitMetadataToDeleteRepository
+  async upsertOneForUnit(unitId: number, manager?: EntityManager) {
+    const repo = manager ? manager.getRepository(UnitMetadataToDelete) : this.unitMetadataToDeleteRepository;
+    await repo
       .upsert(<UnitMetadataToDelete>{ unitId: unitId, changedAt: new Date() }, ['unitId']);
   }
 

--- a/apps/api/src/app/services/unit-metadata.service.spec.ts
+++ b/apps/api/src/app/services/unit-metadata.service.spec.ts
@@ -83,6 +83,23 @@ describe('UnitMetadataService', () => {
       expect(repository.save).toHaveBeenCalledWith(createdEntity);
       expect(result).toBe(123);
     });
+
+    it('sets the NOT NULL columns when the client omits them', async () => {
+      // Regression: created_at/changed_at/is_current are NOT NULL without a DB
+      // default; the profile form re-emits without them, so the INSERT must fill
+      // them or Postgres rejects the row and the save crashes.
+      const dto = { profileId: 'profile1' } as UnitMetadataDto;
+      mockRepository.create.mockImplementation((value: UnitMetadata) => value);
+      mockRepository.save.mockResolvedValue({ id: 5 } as UnitMetadata);
+
+      await service.addMetadata(1, dto);
+
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
+        isCurrent: false,
+        createdAt: expect.any(Date),
+        changedAt: expect.any(Date)
+      }));
+    });
   });
 
   describe('updateMetadata', () => {
@@ -96,7 +113,10 @@ describe('UnitMetadataService', () => {
 
       const result = await service.updateMetadata(id, dto);
 
-      expect(repository.update).toHaveBeenCalledWith(id, dto);
+      expect(repository.update).toHaveBeenCalledWith(
+        id,
+        expect.objectContaining({ profileId: 'p1', changedAt: expect.any(Date) })
+      );
       expect(result).toBe(id);
     });
   });

--- a/apps/api/src/app/services/unit-metadata.service.ts
+++ b/apps/api/src/app/services/unit-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { UnitMetadataDto } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import UnitMetadata from '../entities/unit-metadata.entity';
 
 export class UnitMetadataService {
@@ -12,37 +12,43 @@ export class UnitMetadataService {
     private unitMetadataRepository: Repository<UnitMetadata>
   ) {}
 
+  // When a transactional manager is passed the write joins that transaction;
+  // otherwise the injected repository (default connection) is used.
+  private repo(manager?: EntityManager): Repository<UnitMetadata> {
+    return manager ? manager.getRepository(UnitMetadata) : this.unitMetadataRepository;
+  }
+
   async getAll(): Promise<UnitMetadataDto[]> {
     return this.unitMetadataRepository.find();
   }
 
-  async getAllByUnitId(unitId: number): Promise<UnitMetadataDto[]> {
-    return this.unitMetadataRepository.findBy({ unitId: unitId });
+  async getAllByUnitId(unitId: number, manager?: EntityManager): Promise<UnitMetadataDto[]> {
+    return this.repo(manager).findBy({ unitId: unitId });
   }
 
-  async addMetadata(unitId: number, metadata: UnitMetadataDto): Promise<number> {
+  async addMetadata(unitId: number, metadata: UnitMetadataDto, manager?: EntityManager): Promise<number> {
     metadata.unitId = unitId;
     const { id, ...metadataWithoutId } = metadata;
     // created_at, changed_at and is_current are NOT NULL columns without a DB
     // default. The client cannot supply them (the profile form re-emits without
     // them), so they are set here — otherwise the INSERT violates NOT NULL.
     const now = new Date();
-    const newItemMetadata = this.unitMetadataRepository.create({
+    const newItemMetadata = this.repo(manager).create({
       ...metadataWithoutId,
       isCurrent: metadataWithoutId.isCurrent ?? false,
       createdAt: metadataWithoutId.createdAt ?? now,
       changedAt: now
     });
-    await this.unitMetadataRepository.save(newItemMetadata);
+    await this.repo(manager).save(newItemMetadata);
     return newItemMetadata.id;
   }
 
-  async updateMetadata(id: number, metadata: UnitMetadataDto): Promise<number> {
-    await this.unitMetadataRepository.update(id, { ...metadata, changedAt: new Date() });
+  async updateMetadata(id: number, metadata: UnitMetadataDto, manager?: EntityManager): Promise<number> {
+    await this.repo(manager).update(id, { ...metadata, changedAt: new Date() });
     return id;
   }
 
-  async removeMetadata(id: number): Promise<void> {
-    await this.unitMetadataRepository.delete(id);
+  async removeMetadata(id: number, manager?: EntityManager): Promise<void> {
+    await this.repo(manager).delete(id);
   }
 }

--- a/apps/api/src/app/services/unit-metadata.service.ts
+++ b/apps/api/src/app/services/unit-metadata.service.ts
@@ -23,13 +23,22 @@ export class UnitMetadataService {
   async addMetadata(unitId: number, metadata: UnitMetadataDto): Promise<number> {
     metadata.unitId = unitId;
     const { id, ...metadataWithoutId } = metadata;
-    const newItemMetadata = this.unitMetadataRepository.create(metadataWithoutId);
+    // created_at, changed_at and is_current are NOT NULL columns without a DB
+    // default. The client cannot supply them (the profile form re-emits without
+    // them), so they are set here — otherwise the INSERT violates NOT NULL.
+    const now = new Date();
+    const newItemMetadata = this.unitMetadataRepository.create({
+      ...metadataWithoutId,
+      isCurrent: metadataWithoutId.isCurrent ?? false,
+      createdAt: metadataWithoutId.createdAt ?? now,
+      changedAt: now
+    });
     await this.unitMetadataRepository.save(newItemMetadata);
     return newItemMetadata.id;
   }
 
   async updateMetadata(id: number, metadata: UnitMetadataDto): Promise<number> {
-    await this.unitMetadataRepository.update(id, metadata);
+    await this.unitMetadataRepository.update(id, { ...metadata, changedAt: new Date() });
     return id;
   }
 

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -242,10 +242,10 @@ describe('UnitService', () => {
       await service.patchUnitMetadata(1, [{ profileId: 'p1' } as UnitMetadataDto]);
 
       expect(unitMetadataService.updateMetadata)
-        .toHaveBeenCalledWith(7, expect.objectContaining({ id: 7, profileId: 'p1' }));
+        .toHaveBeenCalledWith(7, expect.objectContaining({ id: 7, profileId: 'p1' }), undefined);
       expect(unitMetadataService.addMetadata).not.toHaveBeenCalled();
       // p2 is gone from the incoming payload -> removed
-      expect(unitMetadataService.removeMetadata).toHaveBeenCalledWith(8);
+      expect(unitMetadataService.removeMetadata).toHaveBeenCalledWith(8, undefined);
     });
 
     it('inserts a profile that has no stored counterpart', async () => {
@@ -254,7 +254,7 @@ describe('UnitService', () => {
       await service.patchUnitMetadata(1, [{ profileId: 'p-new' } as UnitMetadataDto]);
 
       expect(unitMetadataService.addMetadata)
-        .toHaveBeenCalledWith(1, expect.objectContaining({ profileId: 'p-new' }));
+        .toHaveBeenCalledWith(1, expect.objectContaining({ profileId: 'p-new' }), undefined);
       expect(unitMetadataService.removeMetadata).not.toHaveBeenCalled();
     });
   });
@@ -264,6 +264,28 @@ describe('UnitService', () => {
       unitItemService.getAllByUnitIdWithMetadata.mockResolvedValue([]);
       await service.patchItemsMetadata(1, []);
       expect(unitItemService.getAllByUnitIdWithMetadata).toHaveBeenCalled();
+    });
+  });
+
+  describe('patchMetadata', () => {
+    it('runs the whole save in one transaction and threads the manager through', async () => {
+      const manager = createMock<EntityManager>();
+      const transaction = jest.fn().mockImplementation(
+        (runInTransaction: (m: EntityManager) => Promise<unknown>) => runInTransaction(manager)
+      );
+      Object.defineProperty(unitsRepository, 'manager', {
+        value: { transaction } as unknown as EntityManager,
+        configurable: true
+      });
+      unitMetadataService.getAllByUnitId.mockResolvedValue([]);
+      unitItemService.getAllByUnitIdWithMetadata.mockResolvedValue([]);
+
+      await service.patchMetadata(1, { profiles: [], items: [] });
+
+      expect(transaction).toHaveBeenCalled();
+      expect(unitMetadataService.getAllByUnitId).toHaveBeenCalledWith(1, manager);
+      expect(unitItemService.getAllByUnitIdWithMetadata).toHaveBeenCalledWith(1, manager);
+      expect(unitMetadataToDeleteService.upsertOneForUnit).toHaveBeenCalledWith(1, manager);
     });
   });
 

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -5,6 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { EntityManager, QueryFailedError, Repository } from 'typeorm';
 import {
   CreateUnitDto,
+  UnitMetadataDto,
   UnitMetadataValues,
   UnitPropertiesDto,
   UnitSchemeDto
@@ -228,6 +229,33 @@ describe('UnitService', () => {
       unitMetadataService.getAllByUnitId.mockResolvedValue([]);
       await service.patchUnitMetadata(1, []);
       expect(unitMetadataService.getAllByUnitId).toHaveBeenCalled();
+    });
+
+    it('updates the matching stored profile by profileId instead of re-inserting', async () => {
+      // The incoming profile has no row id (the profile form drops it) but keeps
+      // its profileId; it must update the stored row, not delete + re-insert.
+      unitMetadataService.getAllByUnitId.mockResolvedValue([
+        { id: 7, profileId: 'p1' },
+        { id: 8, profileId: 'p2' }
+      ] as UnitMetadataDto[]);
+
+      await service.patchUnitMetadata(1, [{ profileId: 'p1' } as UnitMetadataDto]);
+
+      expect(unitMetadataService.updateMetadata)
+        .toHaveBeenCalledWith(7, expect.objectContaining({ id: 7, profileId: 'p1' }));
+      expect(unitMetadataService.addMetadata).not.toHaveBeenCalled();
+      // p2 is gone from the incoming payload -> removed
+      expect(unitMetadataService.removeMetadata).toHaveBeenCalledWith(8);
+    });
+
+    it('inserts a profile that has no stored counterpart', async () => {
+      unitMetadataService.getAllByUnitId.mockResolvedValue([]);
+
+      await service.patchUnitMetadata(1, [{ profileId: 'p-new' } as UnitMetadataDto]);
+
+      expect(unitMetadataService.addMetadata)
+        .toHaveBeenCalledWith(1, expect.objectContaining({ profileId: 'p-new' }));
+      expect(unitMetadataService.removeMetadata).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -439,26 +439,31 @@ export class UnitService {
     };
   }
 
+  // Match incoming profiles to stored rows by profileId (not by the missing row
+  // id), so an edit updates the existing row instead of deleting and re-inserting
+  // it — which previously dropped created_at/is_current and violated NOT NULL.
   async patchUnitMetadata(unitId: number, profiles: UnitMetadataDto[]): Promise<void> {
-    const profilesToUpdate = await this.unitMetadataService.getAllByUnitId(unitId);
-    const { unchanged, removed, added } = UnitItemService.compare(profilesToUpdate, profiles, 'id');
-    unchanged
-      .map(metadata => this.unitMetadataService.updateMetadata(metadata.id, metadata));
-    removed
-      .map(metadata => this.unitMetadataService.removeMetadata(metadata.id));
-    added
-      .map(metadata => this.unitMetadataService.addMetadata(unitId, metadata));
+    const existingProfiles = await this.unitMetadataService.getAllByUnitId(unitId);
+    const incomingProfileIds = new Set(profiles.map(profile => profile.profileId));
+    const removed = existingProfiles.filter(existing => !incomingProfileIds.has(existing.profileId));
+    await Promise.all(removed
+      .map(profile => this.unitMetadataService.removeMetadata(profile.id)));
+    await Promise.all(profiles.map(profile => {
+      const existing = existingProfiles.find(candidate => candidate.profileId === profile.profileId);
+      return existing ?
+        this.unitMetadataService.updateMetadata(existing.id, UnitItemService.mergeMetadata(existing, profile)) :
+        this.unitMetadataService.addMetadata(unitId, profile);
+    }));
   }
 
   async patchItemsMetadata(unitId: number, items: UnitItemWithMetadataDto[]): Promise<void> {
     const itemsToUpdate = await this.unitItemService.getAllByUnitIdWithMetadata(unitId);
     const { unchanged, removed, added } = UnitItemService.compare(itemsToUpdate, items, 'uuid');
-    unchanged
-      .map(item => this.unitItemService.updateItem(item.uuid, item));
-    removed
-      .map(item => this.unitItemService.removeItem(item.uuid));
-    added
-      .map(item => this.unitItemService.addItem(unitId, item));
+    await Promise.all([
+      ...unchanged.map(item => this.unitItemService.updateItem(item.uuid, item)),
+      ...removed.map(item => this.unitItemService.removeItem(item.uuid)),
+      ...added.map(item => this.unitItemService.addItem(unitId, item))
+    ]);
   }
 
   // Takes the internal write shape: id and unitItemUuid do not exist yet —
@@ -469,9 +474,9 @@ export class UnitService {
     metadata: UnitMetadataValues
   ): Promise<ItemUuidLookup[]> {
     const profiles = metadata.profiles || [];
-    profiles
+    await Promise.all(profiles
       .map(profile => this.unitMetadataService
-        .addMetadata(unitId, profile as UnitMetadataDto));
+        .addMetadata(unitId, profile as UnitMetadataDto)));
     const items = metadata.items || [];
     const itemUuids = await Promise.all(items
       .map(async item => ({
@@ -632,11 +637,10 @@ export class UnitService {
 
   private async patchUnitMetadataCurrentProfile(unitId: number, unitProfile: string): Promise<void> {
     const profilesToUpdate: UnitMetadataDto[] = await this.unitMetadataService.getAllByUnitId(unitId);
-    profilesToUpdate.map(metadata => {
+    await Promise.all(profilesToUpdate.map(metadata => {
       metadata.isCurrent = profileIdsMatch(metadata.profileId, unitProfile);
-      this.unitMetadataService.updateMetadata(metadata.id, metadata);
-      return metadata;
-    });
+      return this.unitMetadataService.updateMetadata(metadata.id, metadata);
+    }));
   }
 
   async copy(unitIds: number[], newWorkspace: number, user: User, addComments: boolean): Promise<RequestReportDto> {

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -19,7 +19,7 @@ import {
   UnitSchemeDto
 } from '@studio-lite-lib/api-dto';
 import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
-import { profileIdsMatch } from '@studio-lite/shared-code';
+import { profileIdsMatch, reconcileProfilesByProfileId } from '@studio-lite/shared-code';
 import Workspace from '../entities/workspace.entity';
 import Unit from '../entities/unit.entity';
 import UnitDefinition from '../entities/unit-definition.entity';
@@ -439,21 +439,15 @@ export class UnitService {
     };
   }
 
-  // Match incoming profiles to stored rows by profileId (not by the missing row
-  // id), so an edit updates the existing row instead of deleting and re-inserting
-  // it — which previously dropped created_at/is_current and violated NOT NULL.
+  // Reconcile unit metadata by profileId (the profile form re-emits without the
+  // row id), so an edit updates the existing row instead of delete + re-insert.
   async patchUnitMetadata(unitId: number, profiles: UnitMetadataDto[]): Promise<void> {
     const existingProfiles = await this.unitMetadataService.getAllByUnitId(unitId);
-    const incomingProfileIds = new Set(profiles.map(profile => profile.profileId));
-    const removed = existingProfiles.filter(existing => !incomingProfileIds.has(existing.profileId));
-    await Promise.all(removed
-      .map(profile => this.unitMetadataService.removeMetadata(profile.id)));
-    await Promise.all(profiles.map(profile => {
-      const existing = existingProfiles.find(candidate => candidate.profileId === profile.profileId);
-      return existing ?
-        this.unitMetadataService.updateMetadata(existing.id, UnitItemService.mergeMetadata(existing, profile)) :
-        this.unitMetadataService.addMetadata(unitId, profile);
-    }));
+    await reconcileProfilesByProfileId(existingProfiles, profiles, {
+      remove: id => this.unitMetadataService.removeMetadata(id),
+      update: (id, metadata) => this.unitMetadataService.updateMetadata(id, metadata),
+      add: metadata => this.unitMetadataService.addMetadata(unitId, metadata)
+    });
   }
 
   async patchItemsMetadata(unitId: number, items: UnitItemWithMetadataDto[]): Promise<void> {

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  In, Not, QueryFailedError, Repository
+  EntityManager, In, Not, QueryFailedError, Repository
 } from 'typeorm';
 import {
   CreateUnitDto,
@@ -441,22 +441,26 @@ export class UnitService {
 
   // Reconcile unit metadata by profileId (the profile form re-emits without the
   // row id), so an edit updates the existing row instead of delete + re-insert.
-  async patchUnitMetadata(unitId: number, profiles: UnitMetadataDto[]): Promise<void> {
-    const existingProfiles = await this.unitMetadataService.getAllByUnitId(unitId);
+  async patchUnitMetadata(unitId: number, profiles: UnitMetadataDto[], manager?: EntityManager): Promise<void> {
+    const existingProfiles = await this.unitMetadataService.getAllByUnitId(unitId, manager);
     await reconcileProfilesByProfileId(existingProfiles, profiles, {
-      remove: id => this.unitMetadataService.removeMetadata(id),
-      update: (id, metadata) => this.unitMetadataService.updateMetadata(id, metadata),
-      add: metadata => this.unitMetadataService.addMetadata(unitId, metadata)
+      remove: id => this.unitMetadataService.removeMetadata(id, manager),
+      update: (id, metadata) => this.unitMetadataService.updateMetadata(id, metadata, manager),
+      add: metadata => this.unitMetadataService.addMetadata(unitId, metadata, manager)
     });
   }
 
-  async patchItemsMetadata(unitId: number, items: UnitItemWithMetadataDto[]): Promise<void> {
-    const itemsToUpdate = await this.unitItemService.getAllByUnitIdWithMetadata(unitId);
+  async patchItemsMetadata(
+    unitId: number,
+    items: UnitItemWithMetadataDto[],
+    manager?: EntityManager
+  ): Promise<void> {
+    const itemsToUpdate = await this.unitItemService.getAllByUnitIdWithMetadata(unitId, manager);
     const { unchanged, removed, added } = UnitItemService.compare(itemsToUpdate, items, 'uuid');
     await Promise.all([
-      ...unchanged.map(item => this.unitItemService.updateItem(item.uuid, item)),
-      ...removed.map(item => this.unitItemService.removeItem(item.uuid)),
-      ...added.map(item => this.unitItemService.addItem(unitId, item))
+      ...unchanged.map(item => this.unitItemService.updateItem(item.uuid, item, manager)),
+      ...removed.map(item => this.unitItemService.removeItem(item.uuid, manager)),
+      ...added.map(item => this.unitItemService.addItem(unitId, item, manager))
     ]);
   }
 
@@ -482,14 +486,17 @@ export class UnitService {
     return itemUuids;
   }
 
+  // The whole metadata save runs in one transaction so a mid-sequence failure
+  // (e.g. a constraint error on one profile) rolls back every write instead of
+  // leaving the unit's profiles/items half-updated.
   async patchMetadata(unitId: number, metadata: UnitMetadataValues): Promise<void> {
     const profiles = metadata.profiles || [];
-    await this.patchUnitMetadata(unitId, profiles as UnitMetadataDto[]);
-
     const items = metadata.items || [];
-    await this.patchItemsMetadata(unitId, items as unknown as UnitItemWithMetadataDto[]);
-
-    await this.unitMetadataToDeleteService.upsertOneForUnit(unitId);
+    await this.unitsRepository.manager.transaction(async manager => {
+      await this.patchUnitMetadata(unitId, profiles as UnitMetadataDto[], manager);
+      await this.patchItemsMetadata(unitId, items as unknown as UnitItemWithMetadataDto[], manager);
+      await this.unitMetadataToDeleteService.upsertOneForUnit(unitId, manager);
+    });
   }
 
   async patchUnit(unitId: number, newData: UnitPropertiesDto, userName: string | null): Promise<void> {

--- a/apps/frontend-e2e/src/support/helpers/review.ts
+++ b/apps/frontend-e2e/src/support/helpers/review.ts
@@ -18,9 +18,15 @@ export function goToReviewAdmin(): void {
  * @param confirmKey - Optional translation key for a confirmation button in a dialog
  */
 function interactWithReview(name: string, actionButtonDataCy: string, confirmKey?: string): void {
+  // Selecting the row triggers an async GET for the review's full data. The
+  // action buttons (e.g. export) stay disabled until that data — including the
+  // unit list — has arrived, so wait for the response before clicking, otherwise
+  // the click lands on a still-disabled button and the dialog never opens.
+  cy.intercept('GET', '/api/workspaces/*/reviews/*').as('getReviewInteraction');
   cy.contains('mat-row', name)
     .should('exist')
     .click();
+  cy.wait('@getReviewInteraction');
   cy.get(`[data-cy="${actionButtonDataCy}"]`)
     .should('be.visible')
     .click();

--- a/libs/shared-code/src/index.ts
+++ b/libs/shared-code/src/index.ts
@@ -2,6 +2,9 @@ export { VeronaModuleFactory } from './lib/helper/verona-module.factory';
 export { VeronaModuleKeyCollection } from './lib/helper/verona-module-key-collection.class';
 export { canonicalizeProfileId, profileIdsMatch, isItemProfileId } from './lib/profile-id';
 export {
+  ReconcilableProfile, ProfileReconcileOps, mergeProfile, reconcileProfilesByProfileId
+} from './lib/metadata-reconcile';
+export {
   ACTIVE_THRESHOLD_MS,
   PASSIVE_THRESHOLD_MS,
   UI_BAR_REFRESH_INTERVAL_MS,

--- a/libs/shared-code/src/lib/metadata-reconcile.spec.ts
+++ b/libs/shared-code/src/lib/metadata-reconcile.spec.ts
@@ -1,0 +1,99 @@
+import { ProfileReconcileOps, mergeProfile, reconcileProfilesByProfileId } from './metadata-reconcile';
+
+interface TestProfile {
+  id: number;
+  profileId?: string;
+  createdAt?: Date;
+  isCurrent?: boolean;
+  entries?: string[];
+}
+
+function makeOps(): ProfileReconcileOps<TestProfile> & {
+  removed: number[];
+  updated: { id: number; metadata: TestProfile }[];
+  added: TestProfile[];
+} {
+  const removed: number[] = [];
+  const updated: { id: number; metadata: TestProfile }[] = [];
+  const added: TestProfile[] = [];
+  return {
+    removed,
+    updated,
+    added,
+    remove: async (id: number) => { removed.push(id); },
+    update: async (id: number, metadata: TestProfile) => { updated.push({ id, metadata }); },
+    add: async (metadata: TestProfile) => { added.push(metadata); }
+  };
+}
+
+describe('mergeProfile', () => {
+  it('keeps id/createdAt from the stored row and entries from the incoming payload', () => {
+    const created = new Date('2020-01-01');
+    const existing: TestProfile = {
+      id: 7, profileId: 'p1', createdAt: created, isCurrent: true, entries: ['old']
+    };
+    const incoming: TestProfile = { id: undefined as unknown as number, profileId: 'p1', entries: ['new'] };
+
+    const merged = mergeProfile(existing, incoming);
+
+    expect(merged.id).toBe(7);
+    expect(merged.createdAt).toBe(created);
+    expect(merged.entries).toEqual(['new']);
+    expect(merged.isCurrent).toBe(true); // inherited because incoming omits it
+  });
+
+  it('takes isCurrent from the incoming payload when present, including false', () => {
+    const existing: TestProfile = { id: 1, profileId: 'p1', isCurrent: true };
+    const incoming: TestProfile = { id: 1, profileId: 'p1', isCurrent: false };
+
+    expect(mergeProfile(existing, incoming).isCurrent).toBe(false);
+  });
+});
+
+describe('reconcileProfilesByProfileId', () => {
+  it('updates matches by profileId, removes gone rows, inserts new ones', async () => {
+    const ops = makeOps();
+    const existing: TestProfile[] = [
+      { id: 2, profileId: 'p1' },
+      { id: 3, profileId: 'p2' }
+    ];
+    const incoming: TestProfile[] = [
+      { id: undefined as unknown as number, profileId: 'p1', entries: ['x'] }, // edit -> update id 2
+      { id: undefined as unknown as number, profileId: 'p3', entries: ['y'] } // new -> add
+    ];
+
+    await reconcileProfilesByProfileId(existing, incoming, ops);
+
+    expect(ops.updated.map(u => u.id)).toEqual([2]);
+    expect(ops.added.map(a => a.profileId)).toEqual(['p3']);
+    expect(ops.removed).toEqual([3]); // p2 no longer present
+  });
+
+  it('clears all stored rows when the incoming array is genuinely empty', async () => {
+    const ops = makeOps();
+    const existing: TestProfile[] = [{ id: 2, profileId: 'p1' }, { id: 3, profileId: 'p2' }];
+
+    await reconcileProfilesByProfileId(existing, [], ops);
+
+    expect(ops.removed.sort()).toEqual([2, 3]);
+    expect(ops.added).toEqual([]);
+    expect(ops.updated).toEqual([]);
+  });
+
+  it('never removes or inserts when an incoming profile has no profileId', async () => {
+    // Regression: an undefined profileId must not poison the match set and wipe
+    // every stored row.
+    const ops = makeOps();
+    const existing: TestProfile[] = [
+      { id: 2, profileId: 'p1' },
+      { id: 3, profileId: 'p2' }
+    ];
+    const incoming: TestProfile[] = [{ id: undefined as unknown as number, entries: ['x'] }];
+
+    await reconcileProfilesByProfileId(existing, incoming, ops);
+
+    expect(ops.removed).toEqual([]);
+    expect(ops.added).toEqual([]);
+    expect(ops.updated).toEqual([]);
+  });
+});

--- a/libs/shared-code/src/lib/metadata-reconcile.ts
+++ b/libs/shared-code/src/lib/metadata-reconcile.ts
@@ -1,0 +1,66 @@
+/**
+ * Reconciling stored metadata rows with an incoming payload.
+ *
+ * The metadata profile form re-emits profiles WITHOUT their persisted row id (and
+ * without created_at/is_current), so the write path cannot match stored rows to
+ * incoming ones by id. It matches by `profileId` instead: a unit / item holds at
+ * most one metadata row per profile, so the profileId is a stable natural key.
+ */
+
+export interface ReconcilableProfile {
+  id: number;
+  profileId?: string;
+  createdAt?: Date;
+  isCurrent?: boolean;
+}
+
+export interface ProfileReconcileOps<T> {
+  remove: (id: number) => Promise<unknown>;
+  update: (id: number, metadata: T) => Promise<unknown>;
+  add: (metadata: T) => Promise<unknown>;
+}
+
+/**
+ * Carry identity, creation time and the current-profile flag over from the stored
+ * row; take everything else (entries/values) from the incoming payload. `isCurrent`
+ * is only inherited when the incoming payload omits it.
+ */
+export function mergeProfile<T extends ReconcilableProfile>(existing: T, incoming: T): T {
+  return {
+    ...existing,
+    ...incoming,
+    id: existing.id,
+    createdAt: existing.createdAt,
+    isCurrent: incoming.isCurrent ?? existing.isCurrent
+  };
+}
+
+/**
+ * Match incoming profiles to stored rows by profileId: remove stored rows whose
+ * profile is gone, update matches in place (keeping their identity), insert
+ * genuinely new profiles.
+ *
+ * Incoming profiles without a profileId are ignored: `profile_id` is a NOT NULL
+ * column so they cannot be persisted anyway. An empty incoming array legitimately
+ * clears all stored metadata, but a NON-empty array that contains only malformed
+ * (profileId-less) entries is treated as untrustworthy and left as a no-op — so a
+ * broken payload can never wipe a unit's/item's entire metadata.
+ */
+export async function reconcileProfilesByProfileId<T extends ReconcilableProfile>(
+  existing: T[],
+  incoming: T[],
+  ops: ProfileReconcileOps<T>
+): Promise<void> {
+  const validIncoming = incoming.filter(profile => profile.profileId !== undefined && profile.profileId !== null);
+  if (incoming.length > 0 && validIncoming.length === 0) return;
+  const incomingProfileIds = new Set(validIncoming.map(profile => profile.profileId));
+  await Promise.all(
+    existing
+      .filter(row => !incomingProfileIds.has(row.profileId))
+      .map(row => ops.remove(row.id))
+  );
+  await Promise.all(validIncoming.map(profile => {
+    const match = existing.find(row => row.profileId === profile.profileId);
+    return match ? ops.update(match.id, mergeProfile(match, profile)) : ops.add(profile);
+  }));
+}


### PR DESCRIPTION
## Problem
Das Speichern/Ändern von Unit- oder Item-Metadaten führte zu einem Fehler bzw. Prozess-Absturz.

## Ursache
Die Metadaten-`ProfileFormComponent` re-emittiert Profile **ohne** ihre Row-`id`. Das Backend verglich per `id`, wodurch jedes Profil als *removed + added* galt. Das Re-Insert lief über `addMetadata`/`addItemMetadata`, die die NOT-NULL-Spalten `created_at`, `changed_at` und `is_current` nie setzten → Postgres wies die Zeile ab. Da die Writes *fire-and-forget* (`.map` ohne `await`) waren, wurde der Fehler zur *unhandled promise rejection*.

## Fix
- **Abgleich per `profileId`** statt der fehlenden `id`: ein Edit **updated** die bestehende Zeile (behält `id`/`created_at`/`is_current`) statt Delete + Reinsert. Gemeinsamer Helper `reconcileProfilesByProfileId` in `shared-code` (von Unit- und Item-Pfad genutzt), inkl. Guard: ein nicht-leeres Payload mit ausschließlich `profileId`-losen Einträgen ist ein No-op (kein Wipe), ein echtes leeres Array löscht weiterhin alles.
- **NOT-NULL-Spalten server-seitig** beim Insert setzen, `changed_at` beim Update bumpen.
- **Alle Writes awaited.**
- **Atomarität:** `patchMetadata` läuft in einer Transaktion (`EntityManager` durch den Write-Pfad gefädelt, Parameter optional → Controller/Copy-Pfad unverändert); ein Fehler mittendrin rollt alles zurück.

## Tests
- Neue Unit-Tests: reconcile (update/insert/remove, profileId-Guard, leeres Array), NOT-NULL beim Insert, Transaktions-Threading.
- Volle API-Suite grün (97 Suites / 700 Tests), Lint & Typecheck grün.

## Review
Enthält bereits die Nachbesserungen aus einem `/code-review high` (profileId-Guard, Entdopplung/Helper, Transaktion). `changed_at` wird bewusst bei jedem Update gesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)