### PR TITLE
Bump metadata-values 3.0.3 & rename MetadataValues → ProfileValues

### DIFF
--- a/apps/api/src/app/classes/unit-download.class.spec.ts
+++ b/apps/api/src/app/classes/unit-download.class.spec.ts
@@ -1,7 +1,7 @@
 import { createMock } from '@golevelup/ts-jest';
 import {
   ItemsMetadataValues,
-  MetadataValues,
+  ProfileValues,
   UnitCommentDto,
   UnitDownloadBookletSettingsDto,
   UnitDownloadSettingsDto,
@@ -1086,7 +1086,7 @@ describe('UnitDownloadClass', () => {
           value: [{ lang: 'de', value: 'Ana Maier' }],
           valueAsText: [{ lang: 'de', value: 'Ana Maier' }]
         }]
-      }] as unknown as MetadataValues[]);
+      }] as unknown as ProfileValues[]);
 
       expect(result).toEqual([{
         profileId: 'https://example.org/profile.json',
@@ -1103,7 +1103,7 @@ describe('UnitDownloadClass', () => {
         { isCurrent: true, entries: [{ id: 'a1', value: 'x', valueAsText: [] }] },
         { profileId: 'p1', entries: [{ id: 'empty', value: [], valueAsText: [] }] },
         { profileId: 'p2', entries: [] }
-      ] as unknown as MetadataValues[]);
+      ] as unknown as ProfileValues[]);
       expect(result).toEqual([]);
     });
 
@@ -1116,7 +1116,7 @@ describe('UnitDownloadClass', () => {
           value: [{ id: 'https://w3id.org/iqb/vocab/l3', text: [{ lang: 'de', value: 'Raum und Form' }] }],
           valueAsText: [{ lang: 'de', value: 'Raum und Form' }]
         }]
-      }] as unknown as MetadataValues[]);
+      }] as unknown as ProfileValues[]);
 
       expect(result[0].entries[0].value).toEqual([{
         id: 'https://w3id.org/iqb/vocab/l3',
@@ -1135,7 +1135,7 @@ describe('UnitDownloadClass', () => {
             id: 'a2', label: [], value: '', valueAsText: []
           }
         ]
-      }] as unknown as MetadataValues[]);
+      }] as unknown as ProfileValues[]);
 
       expect(result[0].entries).toEqual([{
         id: 'a1',
@@ -1152,7 +1152,7 @@ describe('UnitDownloadClass', () => {
           value: 'x',
           valueAsText: [{ value: 'no lang either' }]
         }]
-      }] as unknown as MetadataValues[]);
+      }] as unknown as ProfileValues[]);
 
       expect(result[0].entries).toEqual([{ id: 'a1', value: { raw: 'x' } }]);
     });
@@ -1216,7 +1216,7 @@ describe('UnitDownloadClass', () => {
         entries: [{
           id: 'e1', label: [], value: [{ lang: 'de-DE', value: 'Text' }], valueAsText: []
         }]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(messages).toEqual([{
         unitKey: 'U1',
@@ -1241,7 +1241,7 @@ describe('UnitDownloadClass', () => {
           ],
           valueAsText: []
         }]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(result[0].entries[0].value).toEqual([{ id: 'v1', label: [{ lang: 'de', value: 'A' }] }]);
       expect(messages).toEqual([expect.objectContaining({
@@ -1256,7 +1256,7 @@ describe('UnitDownloadClass', () => {
         entries: [{
           id: 'e1', label: [], value: 'x', valueAsText: []
         }]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(messages).toEqual([expect.objectContaining({
         messageKey: 'dropped-content.profile-not-exported'
@@ -1273,7 +1273,7 @@ describe('UnitDownloadClass', () => {
             id: 'e2', label: [], value: 'x', valueAsText: []
           }
         ]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(result).toHaveLength(1);
       expect(messages).toEqual([{
@@ -1289,7 +1289,7 @@ describe('UnitDownloadClass', () => {
       UnitDownloadClass.transformProfilesToMetadataValues([{
         profileId: 'p1',
         entries: [{ label: [], value: '', valueAsText: [] }]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(messages).toEqual([]);
     });
@@ -1316,7 +1316,7 @@ describe('UnitDownloadClass', () => {
         entries: [{
           id: 'e1', label: [{ lang: 'de', value: 'L' }], value: 'x', valueAsText: []
         }]
-      }] as unknown as MetadataValues[], scope);
+      }] as unknown as ProfileValues[], scope);
 
       expect(messages).toEqual([]);
     });

--- a/apps/api/src/app/classes/unit-download.class.ts
+++ b/apps/api/src/app/classes/unit-download.class.ts
@@ -1,6 +1,6 @@
 import {
   ItemsMetadataValues,
-  MetadataValues,
+  ProfileValues,
   UnitMetadataValues,
   MetadataValuesEntry,
   UnitCommentDto,
@@ -555,7 +555,7 @@ export class UnitDownloadClass {
   // shape. knownMetadataKeys is checked against UnitMetadataValues so a new
   // field on the internal shape fails compilation here instead of producing
   // false warnings.
-  private static hasUnexportedMetadata(metadata?: { profiles?: MetadataValues[] }): boolean {
+  private static hasUnexportedMetadata(metadata?: { profiles?: ProfileValues[] }): boolean {
     if (!metadata) return false;
     if (metadata.profiles?.some(
       profile => (profile?.entries ?? []).some(entry => UnitDownloadClass.entryHasContent(entry))
@@ -627,7 +627,7 @@ export class UnitDownloadClass {
   // profileId and entries with minItems: 1. Every dropped piece that carried
   // content is reported through the scope.
   static transformProfilesToMetadataValues(
-    profiles?: MetadataValues[], scope?: ExportReportScope
+    profiles?: ProfileValues[], scope?: ExportReportScope
   ): MetadataValuesJson[] {
     return (profiles ?? []).flatMap(profile => {
       if (!profile?.profileId) {

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -5,7 +5,7 @@ import {
 } from 'typeorm';
 import {
   CreateUnitDto,
-  MetadataValues,
+  ProfileValues,
   RequestReportDto,
   UnitInViewDto,
   UnitDefinitionDto,
@@ -432,7 +432,7 @@ export class UnitService {
     return user.firstName && user.firstName.trim() ? `${displayName}, ${user.firstName.trim()}` : displayName;
   }
 
-  private static setCurrentProfile<T extends MetadataValues>(profileId: string, profile: T): T {
+  private static setCurrentProfile<T extends ProfileValues>(profileId: string, profile: T): T {
     return {
       ...profile,
       isCurrent: profileIdsMatch(profile.profileId, profileId)

--- a/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.spec.ts
+++ b/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MetadataValues } from '@studio-lite-lib/api-dto';
+import { ProfileValues } from '@studio-lite-lib/api-dto';
 import { MetadataProfileEntriesComponent } from './metadata-profile-entries.component';
 import { IsArrayPipe } from '../../pipes/is-array.pipe';
 import { CastPipe } from '../../pipes/cast.pipe';
@@ -8,7 +8,7 @@ describe('MetadataProfileEntriesComponent', () => {
   let component: MetadataProfileEntriesComponent;
   let fixture: ComponentFixture<MetadataProfileEntriesComponent>;
 
-  const mockProfiles: MetadataValues[] = [
+  const mockProfiles: ProfileValues[] = [
     {
       profileId: 'profile1',
       isCurrent: true,

--- a/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.ts
+++ b/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { MetadataValues } from '@studio-lite-lib/api-dto';
+import { ProfileValues } from '@studio-lite-lib/api-dto';
 import { LanguageCodedText as TextWithLanguage } from '@iqbspecs/metadata-profile';
 import { IsArrayPipe } from '../../pipes/is-array.pipe';
 import { CastPipe } from '../../pipes/cast.pipe';
@@ -14,7 +14,7 @@ import { CastPipe } from '../../pipes/cast.pipe';
   ]
 })
 export class MetadataProfileEntriesComponent {
-  @Input() profiles!: MetadataValues[];
+  @Input() profiles!: ProfileValues[];
 
   TextWithLanguageArray!: TextWithLanguage[];
   TextWithLanguage!: TextWithLanguage;

--- a/apps/frontend/src/app/components/metadata-readonly-items/metadata-readonly-items.component.spec.ts
+++ b/apps/frontend/src/app/components/metadata-readonly-items/metadata-readonly-items.component.spec.ts
@@ -4,7 +4,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import {
   Component, Input, Pipe, PipeTransform
 } from '@angular/core';
-import { ItemsMetadataValues, MetadataValues } from '@studio-lite-lib/api-dto';
+import { ItemsMetadataValues, ProfileValues } from '@studio-lite-lib/api-dto';
 import { MetadataReadonlyItemsComponent } from './metadata-readonly-items.component';
 import { MetadataProfileEntriesComponent } from '../metadata-profile-entries/metadata-profile-entries.component';
 import { VariableIdPipe } from '../../pipes/variable-id.pipe';
@@ -20,7 +20,7 @@ describe('MetadataReadonlyItemsComponent', () => {
     standalone: true
   })
   class MockMetadataProfileEntriesComponent {
-    @Input() profiles!: MetadataValues[];
+    @Input() profiles!: ProfileValues[];
   }
 
   @Pipe({

--- a/apps/frontend/src/app/modules/metadata/components/item/item.component.ts
+++ b/apps/frontend/src/app/modules/metadata/components/item/item.component.ts
@@ -5,7 +5,7 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
-import { ItemsMetadataValues, MetadataValues } from '@studio-lite-lib/api-dto';
+import { ItemsMetadataValues, ProfileValues } from '@studio-lite-lib/api-dto';
 import { MDProfile } from '@iqbspecs/metadata-profile';
 import { MatIcon } from '@angular/material/icon';
 import {
@@ -202,7 +202,7 @@ export class ItemComponent implements OnInit, OnChanges, OnDestroy {
     // Keep the identity of items[itemIndex]: the parent tracks the item list
     // by object identity, so replacing the object collapses the item panel.
     // The profile form only owns 'profiles'; other keys in the event may be stale.
-    this.metadata[this.itemIndex].profiles = metadata.profiles as unknown as MetadataValues[];
+    this.metadata[this.itemIndex].profiles = metadata.profiles as unknown as ProfileValues[];
     this.emitMetadata();
   }
 

--- a/apps/frontend/src/app/modules/print/components/print-metadata/print-metadata.component.spec.ts
+++ b/apps/frontend/src/app/modules/print/components/print-metadata/print-metadata.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SimpleChange } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { ItemsMetadataValues, MetadataValues, UnitMetadataValues } from '@studio-lite-lib/api-dto';
+import { ItemsMetadataValues, ProfileValues, UnitMetadataValues } from '@studio-lite-lib/api-dto';
 import { PrintMetadataComponent } from './print-metadata.component';
 
 describe('PrintMetadataComponent', () => {
@@ -26,7 +26,7 @@ describe('PrintMetadataComponent', () => {
 
   describe('ngOnChanges', () => {
     it('should update unitProfiles and items when metadata changes', () => {
-      const mockProfiles: MetadataValues[] = [
+      const mockProfiles: ProfileValues[] = [
         {
           profileId: 'profile1'
         }
@@ -52,7 +52,7 @@ describe('PrintMetadataComponent', () => {
     });
 
     it('should update unitProfiles when only profiles exist', () => {
-      const mockProfiles: MetadataValues[] = [
+      const mockProfiles: ProfileValues[] = [
         {
           profileId: 'profile1'
         }
@@ -91,7 +91,7 @@ describe('PrintMetadataComponent', () => {
     });
 
     it('should not update properties if metadata is null', () => {
-      const previousProfiles: MetadataValues[] = [
+      const previousProfiles: ProfileValues[] = [
         {
           profileId: 'old'
         }
@@ -106,7 +106,7 @@ describe('PrintMetadataComponent', () => {
     });
 
     it('should not update if changes do not include metadata', () => {
-      const previousProfiles: MetadataValues[] = [
+      const previousProfiles: ProfileValues[] = [
         {
           profileId: 'old'
         }

--- a/apps/frontend/src/app/modules/print/components/print-metadata/print-metadata.component.ts
+++ b/apps/frontend/src/app/modules/print/components/print-metadata/print-metadata.component.ts
@@ -2,7 +2,7 @@ import {
   Component, Input, OnChanges, SimpleChanges
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { ItemsMetadataValues, MetadataValues, UnitMetadataValues } from '@studio-lite-lib/api-dto';
+import { ItemsMetadataValues, ProfileValues, UnitMetadataValues } from '@studio-lite-lib/api-dto';
 import { MetadataReadonlyItemsComponent }
   from '../../../../components/metadata-readonly-items/metadata-readonly-items.component';
 import { MetadataProfileEntriesComponent }
@@ -17,7 +17,7 @@ import { MetadataProfileEntriesComponent }
 export class PrintMetadataComponent implements OnChanges {
   @Input() metadata!: UnitMetadataValues | null;
 
-  unitProfiles!: MetadataValues[];
+  unitProfiles!: ProfileValues[];
   items!: ItemsMetadataValues[];
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/libs/api-dto/src/index.ts
+++ b/libs/api-dto/src/index.ts
@@ -55,7 +55,7 @@ export { UnitCommentVoteDto } from './lib/dtos/unit-comment/unit-comment-vote.dt
 export { UnitCommentVoterDto } from './lib/dtos/unit-comment/unit-comment-voter.dto';
 export { UpdateUnitUserDto } from './lib/dtos/unit-user/update-unit-user.dto';
 export { ProfileMetadataValues } from './lib/dtos/unit/profile-metadata-values.class';
-export { MetadataValues } from './lib/dtos/unit/profile-metadata-values.class';
+export { ProfileValues } from './lib/dtos/unit/profile-metadata-values.class';
 export { ItemsMetadataValues } from './lib/dtos/unit/profile-metadata-values.class';
 export { MetadataValuesEntry } from './lib/dtos/unit/profile-metadata-values.class';
 export { CodebookUnitDto, CodeBookVariable } from './lib/dtos/coding/coding.dto';

--- a/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
+++ b/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
@@ -3,14 +3,14 @@ import { TextWithLanguageAndId as TextsWithLanguageAndId } from '@iqb/metadata-r
 import { LanguageCodedText as TextWithLanguage } from '@iqbspecs/metadata-profile';
 
 export class ProfileMetadataValues {
-  profiles?: MetadataValues[];
+  profiles?: ProfileValues[];
 }
 
 export class UnitMetadataValues extends ProfileMetadataValues {
   items?: ItemsMetadataValues[];
 }
 
-export class MetadataValues {
+export class ProfileValues {
   entries?: MetadataValuesEntry[];
   profileId?: string;
   isCurrent?: boolean;
@@ -29,7 +29,7 @@ export class ItemsMetadataValues extends ProfileMetadataValues {
   variableId?: string | null;
   variableReadOnlyId?: string | null;
   weighting?: number;
-  [key: string]: string | number | MetadataValues[] | null | undefined | boolean | Date;
+  [key: string]: string | number | ProfileValues[] | null | undefined | boolean | Date;
 }
 
 export class MetadataValuesEntry {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@iqbspecs/coding-scheme": "3.4.1",
         "@iqbspecs/metadata-profile": "^0.11.1",
         "@iqbspecs/metadata-store": "^0.4.0",
-        "@iqbspecs/metadata-values": "^3.0.2",
+        "@iqbspecs/metadata-values": "^3.0.3",
         "@iqbspecs/response": "2.0.0",
         "@iqbspecs/variable-info": "1.3.0",
         "@nestjs/axios": "4.0.1",
@@ -5906,9 +5906,9 @@
       "license": "MIT"
     },
     "node_modules/@iqbspecs/metadata-values": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@iqbspecs/metadata-values/-/metadata-values-3.0.2.tgz",
-      "integrity": "sha512-UzAG2QITYMWsdI2rs60T6PARMTzLKvhbEJcNi9Ty/Z53dp/C2Gu2Ptqh4gB7BkGQvGQOZDKXwMJgjCRqNisYgA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@iqbspecs/metadata-values/-/metadata-values-3.0.3.tgz",
+      "integrity": "sha512-YcqQvrsSRT5J+CTqElITKqzsAewa9KVHqYvT7l5PcGSfQgAH9KHkjYTzgIxFUuSH+y9xrRs15eY6V4LKyLIKVw==",
       "license": "CC0 1.0",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@iqbspecs/coding-scheme": "3.4.1",
     "@iqbspecs/metadata-profile": "^0.11.1",
     "@iqbspecs/metadata-store": "^0.4.0",
-    "@iqbspecs/metadata-values": "^3.0.2",
+    "@iqbspecs/metadata-values": "^3.0.3",
     "@iqbspecs/response": "2.0.0",
     "@iqbspecs/variable-info": "1.3.0",
     "@nestjs/axios": "4.0.1",


### PR DESCRIPTION
## Kontext
`@iqbspecs/metadata-values` 3.0.3 ergänzt `export type MetadataValues = MetadataProfileValues[]` — der Name `MetadataValues` bezeichnet in der Spec also das **Array** von Profilwerten. studio-lite nutzte denselben Namen für ein **einzelnes** Profil-Objekt → Namenskollision.

## Änderung
- **Bump** `@iqbspecs/metadata-values` `^3.0.2` → `^3.0.3` (rein additiv, non-breaking).
- **Rename** der studio-lite-Klasse `MetadataValues` (ein Profil) → **`ProfileValues`**, damit `MetadataValues` frei ist und konsistent das Array meint. Wortgrenzen-sichere Umbenennung über 11 Dateien (Definition, Barrel-Export, alle Importer in api/frontend/libs); `UnitMetadataValues`/`ItemsMetadataValues`/`ProfileMetadataValues`/`MetadataValuesEntry` unangetastet.

Reiner Rename + additiver Bump, keine Verhaltensänderung.

## Tests
Typecheck (API/Frontend/Lib), Lint, API 695 + Frontend 1931 Specs, Frontend-Build — alles grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)