### PR TITLE
Metadata: order statt is_current + Spec-Wertform-Fixes

### DIFF
--- a/apps/api/src/app/classes/download-workspaces.class.spec.ts
+++ b/apps/api/src/app/classes/download-workspaces.class.spec.ts
@@ -41,7 +41,7 @@ describe('DownloadWorkspacesClass', () => {
                 description: 'Desc1',
                 profiles: [
                   {
-                    isCurrent: true,
+                    order: 0,
                     entries: [
                       {
                         label: [{ value: 'EntryLabel' }],
@@ -79,7 +79,7 @@ describe('DownloadWorkspacesClass', () => {
                 id: 'ITEM1',
                 profiles: [
                   {
-                    isCurrent: true,
+                    order: 0,
                     entries: [
                       {
                         label: [{ value: 'MultiEntry' }],
@@ -108,7 +108,7 @@ describe('DownloadWorkspacesClass', () => {
           metadata: {
             profiles: [
               {
-                isCurrent: true,
+                order: 0,
                 entries: [
                   {
                     label: [{ value: 'UnitLabel' }],

--- a/apps/api/src/app/classes/download-workspaces.class.ts
+++ b/apps/api/src/app/classes/download-workspaces.class.ts
@@ -6,6 +6,7 @@ import {
   MissingsProfilesDto
 } from '@studio-lite-lib/api-dto';
 import { ToTextFactory, CodeAsText } from '@iqb/responses';
+import { isCurrentFromOrder } from '@studio-lite/shared-code';
 import {
   VariableCodingData,
   CodeData
@@ -59,7 +60,7 @@ export class DownloadWorkspacesClass {
       if (unit.metadata.items) {
         unit.metadata.items.forEach((item, i: number) => {
           const activeProfile = item.profiles?.find(
-            profile => profile.isCurrent
+            profile => isCurrentFromOrder(profile.order)
           );
           if (activeProfile) {
             const values: Record<string, string> = {};
@@ -102,7 +103,7 @@ export class DownloadWorkspacesClass {
     const totalValues: Record<string, string>[] = [];
     units.forEach(unit => {
       const activeProfile = unit.metadata.profiles?.find(
-        profile => profile.isCurrent
+        profile => isCurrentFromOrder(profile.order)
       );
       if (activeProfile) {
         const values: Record<string, string> = {};

--- a/apps/api/src/app/classes/unit-download.class.spec.ts
+++ b/apps/api/src/app/classes/unit-download.class.spec.ts
@@ -1146,6 +1146,41 @@ describe('UnitDownloadClass', () => {
       }]);
     });
 
+    // metadata-values@3.x form-created shapes: the editor stores vocabulary values
+    // with `label` (not the legacy `text`) and simple values as { raw, asText }
+    // objects (not plain strings). The export must handle these, not just the
+    // legacy shapes, or form-edited metadata is lost on JSON export.
+    it('should export form-created vocabulary values that carry label (not text)', () => {
+      const result = UnitDownloadClass.transformProfilesToMetadataValues([{
+        profileId: 'p1',
+        entries: [{
+          id: 'iqb_phones',
+          label: [{ lang: 'de', value: 'Kopfhörereinsatz' }],
+          value: [{ id: 'https://w3id.org/iqb/v24/kh/r5f', label: [{ lang: 'de', value: 'nein' }] }],
+          valueAsText: []
+        }]
+      }] as unknown as ProfileValues[]);
+
+      expect(result[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/v24/kh/r5f',
+        label: [{ lang: 'de', value: 'nein' }]
+      }]);
+    });
+
+    it('should export form-created simple value objects { raw, asText } (not drop them)', () => {
+      const result = UnitDownloadClass.transformProfilesToMetadataValues([{
+        profileId: 'p1',
+        entries: [{
+          id: 'a1',
+          label: [{ lang: 'de', value: 'Für SPF geeignet' }],
+          value: { raw: 'true', asText: [{ lang: 'de', value: 'ja' }] },
+          valueAsText: []
+        }]
+      }] as unknown as ProfileValues[]);
+
+      expect(result[0].entries[0].value).toEqual({ raw: 'true', asText: [{ lang: 'de', value: 'ja' }] });
+    });
+
     it('should drop label and asText entries without a valid two-letter language code', () => {
       const result = UnitDownloadClass.transformProfilesToMetadataValues([{
         profileId: 'p1',

--- a/apps/api/src/app/classes/unit-download.class.spec.ts
+++ b/apps/api/src/app/classes/unit-download.class.spec.ts
@@ -553,7 +553,7 @@ describe('UnitDownloadClass', () => {
         metadata: {
           profiles: [{
             profileId: 'https://example.org/unit-profile.json',
-            isCurrent: true,
+            order: 0,
             entries: [{
               id: 'a1',
               label: [{ lang: 'de', value: 'Autor:in' }],
@@ -719,7 +719,7 @@ describe('UnitDownloadClass', () => {
         metadata: {
           profiles: [{
             profileId: 'https://example.org/unit-profile.json',
-            isCurrent: true,
+            order: 0,
             entries: [{
               id: 'a1',
               label: [{ lang: 'de', value: 'Autor:in' }],
@@ -835,7 +835,7 @@ describe('UnitDownloadClass', () => {
         metadata: {
           profiles: [{
             profileId: 'https://example.org/unit-profile.json',
-            isCurrent: true,
+            order: 0,
             entries: [{
               id: 'a1',
               label: [{ lang: 'de', value: 'Für SPF geeignet' }],
@@ -862,7 +862,7 @@ describe('UnitDownloadClass', () => {
             changedAt: '2025-04-01T00:00:00.000Z',
             profiles: [{
               profileId: 'https://example.org/item-profile.json',
-              isCurrent: true,
+              order: 0,
               entries: [{
                 id: 'w4',
                 label: [{ lang: 'de', value: 'Prozess' }],
@@ -909,6 +909,7 @@ describe('UnitDownloadClass', () => {
         changedAt: '2025-05-01T08:00:00.000Z',
         metadata: [{
           profileId: 'https://example.org/unit-profile.json',
+          order: 0,
           entries: [{
             id: 'a1',
             label: [{ lang: 'de', value: 'Für SPF geeignet' }],
@@ -930,6 +931,7 @@ describe('UnitDownloadClass', () => {
         changedAt: '2025-04-01T00:00:00.000Z',
         metadata: [{
           profileId: 'https://example.org/item-profile.json',
+          order: 0,
           entries: [{
             id: 'w4',
             label: [{ lang: 'de', value: 'Prozess' }],
@@ -1076,10 +1078,10 @@ describe('UnitDownloadClass', () => {
   });
 
   describe('transformProfilesToMetadataValues', () => {
-    it('should map internal profiles to metadata-values@3.0 and drop internal-only fields', () => {
+    it('should map internal profiles to metadata-values@3.0, emit order and drop internal-only fields', () => {
       const result = UnitDownloadClass.transformProfilesToMetadataValues([{
         profileId: 'https://example.org/profile.json',
-        isCurrent: true,
+        order: 0,
         entries: [{
           id: 'iqb_author',
           label: [{ lang: 'de', value: 'Entwickler:in' }],
@@ -1090,6 +1092,7 @@ describe('UnitDownloadClass', () => {
 
       expect(result).toEqual([{
         profileId: 'https://example.org/profile.json',
+        order: 0,
         entries: [{
           id: 'iqb_author',
           label: [{ lang: 'de', value: 'Entwickler:in' }],
@@ -1100,7 +1103,7 @@ describe('UnitDownloadClass', () => {
 
     it('should omit profiles without profileId or without exportable entries', () => {
       const result = UnitDownloadClass.transformProfilesToMetadataValues([
-        { isCurrent: true, entries: [{ id: 'a1', value: 'x', valueAsText: [] }] },
+        { order: 0, entries: [{ id: 'a1', value: 'x', valueAsText: [] }] },
         { profileId: 'p1', entries: [{ id: 'empty', value: [], valueAsText: [] }] },
         { profileId: 'p2', entries: [] }
       ] as unknown as ProfileValues[]);

--- a/apps/api/src/app/classes/unit-download.class.ts
+++ b/apps/api/src/app/classes/unit-download.class.ts
@@ -17,7 +17,7 @@ import {
 } from '@studio-lite-lib/api-dto';
 import * as AdmZip from 'adm-zip';
 import * as XmlBuilder from 'xmlbuilder2';
-import { VeronaModuleKeyCollection } from '@studio-lite/shared-code';
+import { HIDDEN_PROFILE_ORDER, VeronaModuleKeyCollection } from '@studio-lite/shared-code';
 import { XMLBuilder } from 'xmlbuilder2/lib/interfaces';
 import {
   CodingSchemeData,
@@ -621,11 +621,12 @@ export class UnitDownloadClass {
     return undefined;
   }
 
-  // Maps internal profile values onto metadata-values@3.0. Internal-only
-  // fields (isCurrent, valueAsText) are dropped; profiles without profileId
-  // or without any exportable entry are omitted since the spec requires
-  // profileId and entries with minItems: 1. Every dropped piece that carried
-  // content is reported through the scope.
+  // Maps internal profile values onto metadata-values@3.0. The profile `order`
+  // (-1 = hidden/disabled, >= 0 = position) is emitted per spec; the internal-only
+  // `valueAsText` is dropped. Profiles without profileId or without any exportable
+  // entry are omitted since the spec requires profileId and entries with
+  // minItems: 1. Every dropped piece that carried content is reported through the
+  // scope.
   static transformProfilesToMetadataValues(
     profiles?: ProfileValues[], scope?: ExportReportScope
   ): MetadataValuesJson[] {
@@ -652,7 +653,7 @@ export class UnitDownloadClass {
         return [{ id: entry.id, ...(label && { label }), value }];
       });
       if (!entries.length) return [];
-      return [{ profileId: profile.profileId, entries }];
+      return [{ profileId: profile.profileId, order: profile.order ?? HIDDEN_PROFILE_ORDER, entries }];
     });
   }
 

--- a/apps/api/src/app/classes/unit-download.class.ts
+++ b/apps/api/src/app/classes/unit-download.class.ts
@@ -588,6 +588,14 @@ export class UnitDownloadClass {
   // Returns undefined for empty values since the spec requires `value`.
   static transformEntryValue(entry: MetadataValuesEntry, scope?: ExportReportScope): MetadataValueJson | undefined {
     const { value } = entry;
+    // metadata-values@3.x simple value { raw, asText } (form-created). The legacy
+    // form stored the raw value as a plain string, handled just below.
+    if (value && typeof value === 'object' && !Array.isArray(value) && 'raw' in value) {
+      const simple = value as unknown as { raw?: string; asText?: unknown };
+      if (!simple.raw) return undefined;
+      const asText = UnitDownloadClass.toLanguageCodedTexts(simple.asText ?? entry.valueAsText);
+      return { raw: simple.raw, ...(asText && { asText }) };
+    }
     if (typeof value === 'string') {
       if (!value) return undefined;
       const asText = UnitDownloadClass.toLanguageCodedTexts(entry.valueAsText);
@@ -597,9 +605,11 @@ export class UnitDownloadClass {
       const vocabularyEntries = value
         .filter(entryValue => !!entryValue && typeof (entryValue as { id?: unknown }).id === 'string')
         .map(entryValue => {
-          const vocabularyEntry = entryValue as { id: string; text?: unknown };
-          UnitDownloadClass.reportDroppedTexts(vocabularyEntry.text, entry.id, scope);
-          const label = UnitDownloadClass.toLanguageCodedTexts(vocabularyEntry.text);
+          const vocabularyEntry = entryValue as { id: string; label?: unknown; text?: unknown };
+          // metadata-values@3.x carries the vocab text in `label`, the legacy form in `text`.
+          const texts = vocabularyEntry.label ?? vocabularyEntry.text;
+          UnitDownloadClass.reportDroppedTexts(texts, entry.id, scope);
+          const label = UnitDownloadClass.toLanguageCodedTexts(texts);
           return {
             id: vocabularyEntry.id,
             ...(label && { label })

--- a/apps/api/src/app/entities/metadata.entity.ts
+++ b/apps/api/src/app/entities/metadata.entity.ts
@@ -19,9 +19,11 @@ class Metadata {
     profileId: string;
 
   @Column({
-    name: 'is_current'
+    name: 'order',
+    type: 'integer',
+    default: -1
   })
-    isCurrent: boolean;
+    order: number;
 
   @Column({
     type: 'timestamp with time zone',

--- a/apps/api/src/app/services/unit-item-metadata.service.ts
+++ b/apps/api/src/app/services/unit-item-metadata.service.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { UnitItemMetadataDto } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
+import { HIDDEN_PROFILE_ORDER } from '@studio-lite/shared-code';
 import UnitItemMetadata from '../entities/unit-item-metadata.entity';
 
 export class UnitItemMetadataService {
@@ -29,13 +30,14 @@ export class UnitItemMetadataService {
   async addItemMetadata(unitItemUuid: string, metadata: UnitItemMetadataDto, manager?: EntityManager): Promise<number> {
     metadata.unitItemUuid = unitItemUuid;
     const { id, ...metadataWithoutId } = metadata;
-    // created_at, changed_at and is_current are NOT NULL columns without a DB
-    // default. The client cannot supply them (the profile form re-emits without
-    // them), so they are set here — otherwise the INSERT violates NOT NULL.
+    // created_at and changed_at are NOT NULL columns without a DB default and the
+    // client cannot supply them (the profile form re-emits without them), so they
+    // are set here — otherwise the INSERT violates NOT NULL. `order` defaults to
+    // -1 (hidden) when the client omits it.
     const now = new Date();
     const newItemMetadata = this.repo(manager).create({
       ...metadataWithoutId,
-      isCurrent: metadataWithoutId.isCurrent ?? false,
+      order: metadataWithoutId.order ?? HIDDEN_PROFILE_ORDER,
       createdAt: metadataWithoutId.createdAt ?? now,
       changedAt: now
     });

--- a/apps/api/src/app/services/unit-item.service.ts
+++ b/apps/api/src/app/services/unit-item.service.ts
@@ -4,7 +4,9 @@ import {
 } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, In, Repository } from 'typeorm';
-import { profileIdsMatch, reconcileProfilesByProfileId } from '@studio-lite/shared-code';
+import {
+  orderFromCurrent, profileIdsMatch, reconcileProfilesByProfileId
+} from '@studio-lite/shared-code';
 import UnitItem from '../entities/unit-item.entity';
 import { UnitItemMetadataService } from './unit-item-metadata.service';
 import { ItemCommentService } from './item-comment.service';
@@ -113,7 +115,7 @@ export class UnitItemService {
     const itemsToUpdate: UnitItemWithMetadataDto[] = await this.getAllByUnitIdWithMetadata(unitId);
     const profiles = itemsToUpdate.flatMap(metadata => metadata.profiles);
     await Promise.all(profiles.map(metadata => {
-      metadata.isCurrent = profileIdsMatch(metadata.profileId, itemProfile);
+      metadata.order = orderFromCurrent(profileIdsMatch(metadata.profileId, itemProfile));
       return this.unitItemMetadataService.updateItemMetadata(metadata.id, metadata);
     }));
   }

--- a/apps/api/src/app/services/unit-metadata-to-delete.service.spec.ts
+++ b/apps/api/src/app/services/unit-metadata-to-delete.service.spec.ts
@@ -44,7 +44,11 @@ describe('UnitMetadataToDeleteService', () => {
       await service.upsertOneForUnit(unitId);
 
       expect(repository.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({ unitId }),
+        expect.objectContaining({
+          unitId,
+          createdAt: expect.any(Date),
+          changedAt: expect.any(Date)
+        }),
         ['unitId']
       );
     });

--- a/apps/api/src/app/services/unit-metadata-to-delete.service.ts
+++ b/apps/api/src/app/services/unit-metadata-to-delete.service.ts
@@ -11,8 +11,9 @@ export class UnitMetadataToDeleteService {
 
   async upsertOneForUnit(unitId: number, manager?: EntityManager) {
     const repo = manager ? manager.getRepository(UnitMetadataToDelete) : this.unitMetadataToDeleteRepository;
+    const now = new Date();
     await repo
-      .upsert(<UnitMetadataToDelete>{ unitId: unitId, changedAt: new Date() }, ['unitId']);
+      .upsert(<UnitMetadataToDelete>{ unitId: unitId, createdAt: now, changedAt: now }, ['unitId']);
   }
 
   async getOneByUnit(unitId: number): Promise<UnitMetadataToDelete> {

--- a/apps/api/src/app/services/unit-metadata.service.spec.ts
+++ b/apps/api/src/app/services/unit-metadata.service.spec.ts
@@ -84,10 +84,10 @@ describe('UnitMetadataService', () => {
       expect(result).toBe(123);
     });
 
-    it('sets the NOT NULL columns when the client omits them', async () => {
-      // Regression: created_at/changed_at/is_current are NOT NULL without a DB
-      // default; the profile form re-emits without them, so the INSERT must fill
-      // them or Postgres rejects the row and the save crashes.
+    it('sets the NOT NULL columns and default order when the client omits them', async () => {
+      // Regression: created_at/changed_at are NOT NULL without a DB default; the
+      // profile form re-emits without them, so the INSERT must fill them or
+      // Postgres rejects the row and the save crashes. `order` defaults to -1.
       const dto = { profileId: 'profile1' } as UnitMetadataDto;
       mockRepository.create.mockImplementation((value: UnitMetadata) => value);
       mockRepository.save.mockResolvedValue({ id: 5 } as UnitMetadata);
@@ -95,7 +95,7 @@ describe('UnitMetadataService', () => {
       await service.addMetadata(1, dto);
 
       expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
-        isCurrent: false,
+        order: -1,
         createdAt: expect.any(Date),
         changedAt: expect.any(Date)
       }));

--- a/apps/api/src/app/services/unit-metadata.service.ts
+++ b/apps/api/src/app/services/unit-metadata.service.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { UnitMetadataDto } from '@studio-lite-lib/api-dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
+import { HIDDEN_PROFILE_ORDER } from '@studio-lite/shared-code';
 import UnitMetadata from '../entities/unit-metadata.entity';
 
 export class UnitMetadataService {
@@ -29,13 +30,14 @@ export class UnitMetadataService {
   async addMetadata(unitId: number, metadata: UnitMetadataDto, manager?: EntityManager): Promise<number> {
     metadata.unitId = unitId;
     const { id, ...metadataWithoutId } = metadata;
-    // created_at, changed_at and is_current are NOT NULL columns without a DB
-    // default. The client cannot supply them (the profile form re-emits without
-    // them), so they are set here — otherwise the INSERT violates NOT NULL.
+    // created_at and changed_at are NOT NULL columns without a DB default and the
+    // client cannot supply them (the profile form re-emits without them), so they
+    // are set here — otherwise the INSERT violates NOT NULL. `order` defaults to
+    // -1 (hidden) when the client omits it.
     const now = new Date();
     const newItemMetadata = this.repo(manager).create({
       ...metadataWithoutId,
-      isCurrent: metadataWithoutId.isCurrent ?? false,
+      order: metadataWithoutId.order ?? HIDDEN_PROFILE_ORDER,
       createdAt: metadataWithoutId.createdAt ?? now,
       changedAt: now
     });

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -277,6 +277,8 @@ describe('UnitService', () => {
         value: { transaction } as unknown as EntityManager,
         configurable: true
       });
+      unitsRepository.findOne.mockResolvedValue({ id: 1, workspaceId: 10 } as Unit);
+      workspaceRepository.findOne.mockResolvedValue({ id: 10, settings: {} } as unknown as Workspace);
       unitMetadataService.getAllByUnitId.mockResolvedValue([]);
       unitItemService.getAllByUnitIdWithMetadata.mockResolvedValue([]);
 
@@ -286,6 +288,35 @@ describe('UnitService', () => {
       expect(unitMetadataService.getAllByUnitId).toHaveBeenCalledWith(1, manager);
       expect(unitItemService.getAllByUnitIdWithMetadata).toHaveBeenCalledWith(1, manager);
       expect(unitMetadataToDeleteService.upsertOneForUnit).toHaveBeenCalledWith(1, manager);
+    });
+
+    it('flags the current profile as order 0 from the workspace settings on save', async () => {
+      const manager = createMock<EntityManager>();
+      const transaction = jest.fn().mockImplementation(
+        (runInTransaction: (m: EntityManager) => Promise<unknown>) => runInTransaction(manager)
+      );
+      Object.defineProperty(unitsRepository, 'manager', {
+        value: { transaction } as unknown as EntityManager,
+        configurable: true
+      });
+      unitsRepository.findOne.mockResolvedValue({ id: 1, workspaceId: 10 } as Unit);
+      workspaceRepository.findOne.mockResolvedValue({
+        id: 10,
+        settings: { unitMDProfile: 'profile-a', itemMDProfile: 'profile-b' }
+      } as unknown as Workspace);
+      unitMetadataService.getAllByUnitId.mockResolvedValue([]);
+      unitItemService.getAllByUnitIdWithMetadata.mockResolvedValue([]);
+
+      const patchUnitMetadataSpy = jest.spyOn(service, 'patchUnitMetadata').mockResolvedValue();
+      jest.spyOn(service, 'patchItemsMetadata').mockResolvedValue();
+
+      await service.patchMetadata(1, {
+        profiles: [{ profileId: 'profile-a' }, { profileId: 'other' }]
+      });
+
+      const savedProfiles = patchUnitMetadataSpy.mock.calls[0][1];
+      expect(savedProfiles[0]).toMatchObject({ profileId: 'profile-a', order: 0 });
+      expect(savedProfiles[1]).toMatchObject({ profileId: 'other', order: -1 });
     });
   });
 

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -449,8 +449,8 @@ describe('UnitService', () => {
         items: []
       } as UnitMetadataValues;
       const result = UnitService.setCurrentProfiles('p1', 'p2', metadata);
-      expect(result.profiles[0].isCurrent).toBe(true);
-      expect(result.profiles[1].isCurrent).toBe(false);
+      expect(result.profiles[0].order).toBe(0);
+      expect(result.profiles[1].order).toBe(-1);
     });
   });
 

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -504,6 +504,39 @@ describe('UnitService', () => {
       expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
     });
 
+    it('derives valueAsText from form-created vocabulary entries that carry label', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [],
+            value: [{ id: 'https://w3id.org/iqb/v24/kh/r5f', label: [{ lang: 'de', value: 'nein' }] }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'nein' }]);
+    });
+
+    it('derives valueAsText from a form-created simple value object { raw, asText }', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1', label: [], value: { raw: 'true', asText: [{ lang: 'de', value: 'ja' }] }, valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'ja' }]);
+    });
+
     it('tolerates a null element in a vocabulary value array without crashing', () => {
       const metadata = {
         profiles: [{

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -454,6 +454,100 @@ describe('UnitService', () => {
     });
   });
 
+  describe('ensureValueAsText', () => {
+    it('derives valueAsText from vocabulary entries (text, not label)', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [{ lang: 'de', value: 'Prozess' }],
+            value: [{ id: 'https://w3id.org/iqb/vocab/p2', text: [{ lang: 'de', value: 'Anwenden' }] }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
+    });
+
+    it('keeps multilingual free text arrays as valueAsText', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [],
+            value: [{ lang: 'de', value: 'Freitext' }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Freitext' }]);
+    });
+
+    it('leaves valueAsText empty for a plain string value (not derivable)', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1', label: [], value: 'false', valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([]);
+    });
+
+    it('does not overwrite an existing valueAsText', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [],
+            value: [{ id: 'v', text: [{ lang: 'de', value: 'Neu' }] }],
+            valueAsText: [{ lang: 'de', value: 'Alt' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Alt' }]);
+    });
+
+    it('fills item profile entries and does not mutate the input', () => {
+      const metadata = {
+        items: [{
+          id: 'ITEM1',
+          profiles: [{
+            profileId: 'ip1',
+            entries: [{
+              id: 'e1',
+              label: [],
+              value: [{ id: 'v', text: [{ lang: 'de', value: 'Anwenden' }] }],
+              valueAsText: []
+            }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.items[0].profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
+      // input untouched
+      expect(metadata.items[0].profiles[0].entries[0].valueAsText).toEqual([]);
+    });
+  });
+
   describe('findOnesMetadata', () => {
     it('should return metadata', async () => {
       unitMetadataService.getAllByUnitId.mockResolvedValue([]);

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -504,6 +504,24 @@ describe('UnitService', () => {
       expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
     });
 
+    it('tolerates a null element in a vocabulary value array without crashing', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [],
+            value: [{ id: 'v', text: [{ lang: 'de', value: 'Anwenden' }] }, null],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
+    });
+
     it('keeps multilingual free text arrays as valueAsText', () => {
       const metadata = {
         profiles: [{

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -533,9 +533,23 @@ export class UnitService {
   // The whole metadata save runs in one transaction so a mid-sequence failure
   // (e.g. a constraint error on one profile) rolls back every write instead of
   // leaving the unit's profiles/items half-updated.
+  //
+  // The profile form re-emits profiles without `order`, so the current profile
+  // must be flagged here from the workspace settings — otherwise a newly stored
+  // profile keeps the -1 (hidden) insert default and, because the read path uses
+  // the normalized tables (permanent unit_metadata_to_delete marker) without
+  // re-deriving, it would be read back as hidden.
   async patchMetadata(unitId: number, metadata: UnitMetadataValues): Promise<void> {
-    const profiles = metadata.profiles || [];
-    const items = metadata.items || [];
+    const unit = await this.unitsRepository.findOne({ where: { id: unitId } });
+    if (!unit) throw new UnitNotFoundException(unitId, 0, 'PATCH');
+    const workspace = await this.workspaceRepository.findOne({ where: { id: unit.workspaceId } });
+    const withOrder = UnitService.setCurrentProfiles(
+      workspace?.settings?.unitMDProfile,
+      workspace?.settings?.itemMDProfile,
+      metadata
+    );
+    const profiles = withOrder.profiles || [];
+    const items = withOrder.items || [];
     await this.unitsRepository.manager.transaction(async manager => {
       await this.patchUnitMetadata(unitId, profiles as UnitMetadataDto[], manager);
       await this.patchItemsMetadata(unitId, items as unknown as UnitItemWithMetadataDto[], manager);

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -19,7 +19,9 @@ import {
   UnitSchemeDto
 } from '@studio-lite-lib/api-dto';
 import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
-import { profileIdsMatch, reconcileProfilesByProfileId } from '@studio-lite/shared-code';
+import {
+  orderFromCurrent, profileIdsMatch, reconcileProfilesByProfileId
+} from '@studio-lite/shared-code';
 import Workspace from '../entities/workspace.entity';
 import Unit from '../entities/unit.entity';
 import UnitDefinition from '../entities/unit-definition.entity';
@@ -435,7 +437,7 @@ export class UnitService {
   private static setCurrentProfile<T extends ProfileValues>(profileId: string, profile: T): T {
     return {
       ...profile,
-      isCurrent: profileIdsMatch(profile.profileId, profileId)
+      order: orderFromCurrent(profileIdsMatch(profile.profileId, profileId))
     };
   }
 
@@ -639,7 +641,7 @@ export class UnitService {
   private async patchUnitMetadataCurrentProfile(unitId: number, unitProfile: string): Promise<void> {
     const profilesToUpdate: UnitMetadataDto[] = await this.unitMetadataService.getAllByUnitId(unitId);
     await Promise.all(profilesToUpdate.map(metadata => {
-      metadata.isCurrent = profileIdsMatch(metadata.profileId, unitProfile);
+      metadata.order = orderFromCurrent(profileIdsMatch(metadata.profileId, unitProfile));
       return this.unitMetadataService.updateMetadata(metadata.id, metadata);
     }));
   }

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -263,12 +263,12 @@ export class UnitService {
         newUnit.lastChangedScheme = unitSourceData.lastChangedScheme || null;
         await this.unitsRepository.save(newUnit);
 
-        const metadata = await this.getMetadataOfUnit(newUnit, unit.createFrom);
+        const rawMetadata = await this.getMetadataOfUnit(newUnit, unit.createFrom);
         const workspace = await this.workspaceRepository.findOne({ where: { id: workspaceId } });
-        UnitService.setCurrentProfiles(
+        const metadata = UnitService.setCurrentProfiles(
           workspace.settings?.unitMDProfile,
           workspace.settings?.itemMDProfile,
-          metadata
+          rawMetadata
         );
         const itemUuidLookups = await this.copyItemsWithMetadata(newUnit.id, metadata);
 
@@ -395,33 +395,38 @@ export class UnitService {
   private async getModifiedMetadataForUnit(unit: Unit, workspace: Workspace): Promise<Unit> {
     const unitMetadataToDelete = await this.unitMetadataToDeleteService.getOneByUnit(unit.id);
     if (unitMetadataToDelete) {
+      // findOnesMetadata already backfills valueAsText.
       unit.metadata = await this.findOnesMetadata(unit.id);
     } else {
-      unit.metadata = UnitService.setCurrentProfiles(
-        workspace.settings?.unitMDProfile,
-        workspace.settings?.itemMDProfile,
-        unit.metadata);
+      unit.metadata = UnitService.ensureValueAsText(
+        UnitService.setCurrentProfiles(
+          workspace.settings?.unitMDProfile,
+          workspace.settings?.itemMDProfile,
+          unit.metadata
+        )
+      );
     }
-    unit.metadata = UnitService.ensureValueAsText(unit.metadata as UnitMetadataValues);
     return unit;
   }
 
   static setCurrentProfiles(
     unitProfile: string, itemProfile: string, metadata: UnitMetadataValues
   ): UnitMetadataValues {
-    if (metadata.profiles) {
-      metadata.profiles = metadata.profiles.map(profile => UnitService
-        .setCurrentProfile(unitProfile, profile));
-    }
-    if (metadata.items) {
-      metadata.items.forEach(item => {
-        if (item.profiles) {
-          item.profiles = item.profiles.map(profile => UnitService
-            .setCurrentProfile(itemProfile, profile));
-        }
-      });
-    }
-    return metadata;
+    if (!metadata) return metadata;
+    return {
+      ...metadata,
+      ...(metadata.profiles && {
+        profiles: metadata.profiles.map(profile => UnitService.setCurrentProfile(unitProfile, profile))
+      }),
+      ...(metadata.items && {
+        items: metadata.items.map(item => ({
+          ...item,
+          ...(item.profiles && {
+            profiles: item.profiles.map(profile => UnitService.setCurrentProfile(itemProfile, profile))
+          })
+        }))
+      })
+    };
   }
 
   async getDisplayNameForUser(id: number): Promise<string> {
@@ -477,7 +482,7 @@ export class UnitService {
   private static getEntryValueAsText(value: MetadataValuesEntry['value']): MetadataValuesEntry['valueAsText'] {
     if (!Array.isArray(value)) return [];
     if (value.some(item => item && typeof item === 'object' && 'id' in item)) {
-      return value.flatMap(item => ('id' in item ? item.text ?? [] : []));
+      return value.flatMap(item => (item && typeof item === 'object' && 'id' in item ? item.text ?? [] : []));
     }
     // no vocabulary entries -> already multilingual free text
     return value as MetadataValuesEntry['valueAsText'];

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -480,9 +480,20 @@ export class UnitService {
   }
 
   private static getEntryValueAsText(value: MetadataValuesEntry['value']): MetadataValuesEntry['valueAsText'] {
+    // metadata-values@3.x simple value { raw, asText } (form-created; the legacy
+    // form stored a plain string instead and has no asText to recover).
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return (value as unknown as { asText?: MetadataValuesEntry['valueAsText'] }).asText ?? [];
+    }
     if (!Array.isArray(value)) return [];
     if (value.some(item => item && typeof item === 'object' && 'id' in item)) {
-      return value.flatMap(item => (item && typeof item === 'object' && 'id' in item ? item.text ?? [] : []));
+      // vocabulary entries: metadata-values@3.x carries the display text in `label`,
+      // the legacy internal form in `text`.
+      return value.flatMap(item => {
+        if (!item || typeof item !== 'object' || !('id' in item)) return [];
+        const vocab = item as { label?: unknown[]; text?: unknown[] };
+        return vocab.label ?? vocab.text ?? [];
+      }) as MetadataValuesEntry['valueAsText'];
     }
     // no vocabulary entries -> already multilingual free text
     return value as MetadataValuesEntry['valueAsText'];

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -5,6 +5,7 @@ import {
 } from 'typeorm';
 import {
   CreateUnitDto,
+  MetadataValuesEntry,
   ProfileValues,
   RequestReportDto,
   UnitInViewDto,
@@ -401,6 +402,7 @@ export class UnitService {
         workspace.settings?.itemMDProfile,
         unit.metadata);
     }
+    unit.metadata = UnitService.ensureValueAsText(unit.metadata as UnitMetadataValues);
     return unit;
   }
 
@@ -439,6 +441,46 @@ export class UnitService {
       ...profile,
       order: orderFromCurrent(profileIdsMatch(profile.profileId, profileId))
     };
+  }
+
+  // Backfill a display text (valueAsText) for entries that have none, e.g. rows
+  // stored before valueAsText was populated. Only structured values carry their
+  // own text: vocabulary entries hold it in `text`, multilingual free text is
+  // already language-coded. A plain string cannot be resolved here (a coded value
+  // needs its vocabulary, free text carries no language), so it is left empty
+  // rather than guessed. Returns new objects; the stored entities are not mutated.
+  static ensureValueAsText(metadata: UnitMetadataValues): UnitMetadataValues {
+    if (!metadata) return metadata;
+    return {
+      ...metadata,
+      ...(metadata.profiles && { profiles: metadata.profiles.map(UnitService.fillProfileValueAsText) }),
+      ...(metadata.items && {
+        items: metadata.items.map(item => ({
+          ...item,
+          ...(item.profiles && { profiles: item.profiles.map(UnitService.fillProfileValueAsText) })
+        }))
+      })
+    };
+  }
+
+  private static fillProfileValueAsText<T extends ProfileValues>(profile: T): T {
+    if (!profile.entries) return profile;
+    return { ...profile, entries: profile.entries.map(UnitService.fillEntryValueAsText) };
+  }
+
+  private static fillEntryValueAsText(entry: MetadataValuesEntry): MetadataValuesEntry {
+    const hasText = Array.isArray(entry.valueAsText) ? entry.valueAsText.length > 0 : !!entry.valueAsText;
+    if (hasText) return entry;
+    return { ...entry, valueAsText: UnitService.getEntryValueAsText(entry.value) };
+  }
+
+  private static getEntryValueAsText(value: MetadataValuesEntry['value']): MetadataValuesEntry['valueAsText'] {
+    if (!Array.isArray(value)) return [];
+    if (value.some(item => item && typeof item === 'object' && 'id' in item)) {
+      return value.flatMap(item => ('id' in item ? item.text ?? [] : []));
+    }
+    // no vocabulary entries -> already multilingual free text
+    return value as MetadataValuesEntry['valueAsText'];
   }
 
   // Reconcile unit metadata by profileId (the profile form re-emits without the
@@ -837,13 +879,15 @@ export class UnitService {
       // the index signature of ItemsMetadataValues blocks direct assignment
       return await this.findOnesMetadata(createFrom) as unknown as UnitMetadataValues;
     }
-    return unit.metadata;
+    return UnitService.ensureValueAsText(unit.metadata as UnitMetadataValues);
   }
 
   async findOnesMetadata(unitId: number): Promise<UnitFullMetadataDto> {
-    return {
+    const metadata: UnitMetadataValues = {
       profiles: await this.unitMetadataService.getAllByUnitId(unitId),
-      items: await this.unitItemService.getAllByUnitIdWithMetadata(unitId)
+      items: await this.unitItemService
+        .getAllByUnitIdWithMetadata(unitId) as unknown as UnitMetadataValues['items']
     };
+    return UnitService.ensureValueAsText(metadata) as unknown as UnitFullMetadataDto;
   }
 }

--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -491,13 +491,22 @@ describe('WorkspaceService', () => {
       });
     });
 
-    it('passes a legacy raw { profiles, items } blob through unchanged', () => {
+    it('normalizes a legacy raw { profiles, items } blob, deriving order from isCurrent', () => {
       const legacy = {
-        profiles: [{ profileId: 'p1', isCurrent: true, entries: [] }],
-        items: [{ id: 'ITEM1', profiles: [] }]
+        profiles: [
+          { profileId: 'p1', isCurrent: true, entries: [] },
+          { profileId: 'p2', isCurrent: false, entries: [] }
+        ],
+        items: [{ id: 'ITEM1', profiles: [{ profileId: 'ip1', isCurrent: true, entries: [] }] }]
       };
 
-      expect(WorkspaceService.mapImportedMetadata(legacy)).toBe(legacy);
+      expect(WorkspaceService.mapImportedMetadata(legacy)).toEqual({
+        profiles: [
+          { profileId: 'p1', order: 0, entries: [] },
+          { profileId: 'p2', order: -1, entries: [] }
+        ],
+        items: [{ id: 'ITEM1', profiles: [{ profileId: 'ip1', order: 0, entries: [] }] }]
+      });
     });
   });
 
@@ -727,7 +736,7 @@ describe('WorkspaceService', () => {
       expect(unitService.copyItemsWithMetadata).toHaveBeenCalledWith(10, {
         profiles: [{
           profileId: 'https://example.org/unit-profile.json',
-          isCurrent: false,
+          order: -1,
           entries: [{
             id: 'a1',
             label: [{ lang: 'de', value: 'Für SPF geeignet' }],
@@ -769,7 +778,7 @@ describe('WorkspaceService', () => {
 
       expect(result.messages).toHaveLength(0);
       expect(unitService.copyItemsWithMetadata).toHaveBeenCalledWith(10, {
-        profiles: [{ profileId: 'p1', isCurrent: false, entries: [] }],
+        profiles: [{ profileId: 'p1', order: -1, entries: [] }],
         items: [{ id: 'ITEM1', variableId: 'VAR1', profiles: [] }]
       });
     });

--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -508,6 +508,20 @@ describe('WorkspaceService', () => {
         items: [{ id: 'ITEM1', profiles: [{ profileId: 'ip1', order: 0, entries: [] }] }]
       });
     });
+
+    it('keeps an explicit order on a legacy profile instead of deriving from isCurrent', () => {
+      const legacy = {
+        profiles: [{
+          profileId: 'p1', order: 2, isCurrent: false, entries: []
+        }],
+        items: []
+      };
+
+      expect(WorkspaceService.mapImportedMetadata(legacy)).toEqual({
+        profiles: [{ profileId: 'p1', order: 2, entries: [] }],
+        items: []
+      });
+    });
   });
 
   describe('mapImportedItems', () => {

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -17,9 +17,11 @@ import {
   RenameGroupNameDto,
   ItemsMetadataValues,
   MetadataValuesEntry,
+  ProfileValues,
   UnitCommentDto,
   UnitMetadataValues
 } from '@studio-lite-lib/api-dto';
+import { orderFromCurrent } from '@studio-lite/shared-code';
 import * as AdmZip from 'adm-zip';
 import {
   VariableCodingData,
@@ -1125,19 +1127,39 @@ export class WorkspaceService {
         profiles: WorkspaceService.mapMetadataValuesJson(wrapper.metadata)
       };
     }
-    return (parsed ?? {}) as UnitMetadataValues;
+    return WorkspaceService.normalizeLegacyProfileOrder((parsed ?? {}) as UnitMetadataValues);
   }
 
-  // Maps metadata-values@3.0 profiles back onto the internal structure.
-  // isCurrent is not restored here; setCurrentProfiles assigns it against
+  // Legacy raw-blob exports predate the metadata-values@3.x `order` field and
+  // carry the obsolete boolean `isCurrent` on each profile. Derive `order` from
+  // it (true -> 0, false -> -1) and drop the flag so the imported structure
+  // matches the current model. A profile that already carries `order` keeps it.
+  private static normalizeLegacyProfileOrder(metadata: UnitMetadataValues): UnitMetadataValues {
+    const mapProfile = (profile: ProfileValues & { isCurrent?: boolean }): ProfileValues => {
+      const { isCurrent, ...rest } = profile;
+      return { ...rest, order: profile.order ?? orderFromCurrent(!!isCurrent) };
+    };
+    return {
+      ...metadata,
+      profiles: metadata.profiles?.map(mapProfile),
+      items: metadata.items?.map(item => ({
+        ...item,
+        profiles: item.profiles?.map(mapProfile)
+      }))
+    };
+  }
+
+  // Maps metadata-values@3.0 profiles back onto the internal structure. The
+  // profile `order` is carried through; setCurrentProfiles reasserts it against
   // the workspace profile settings during import.
   static mapMetadataValuesJson(
     values: MetadataValuesJson[]
-  ): { profileId: string; entries: MetadataValuesEntry[] }[] {
+  ): { profileId: string; order?: number; entries: MetadataValuesEntry[] }[] {
     return (values ?? [])
       .filter(profile => !!profile?.profileId)
       .map(profile => ({
         profileId: profile.profileId,
+        order: profile.order,
         entries: (profile.entries ?? [])
           .filter(entry => !!entry?.id)
           .map(entry => WorkspaceService.mapMetadataEntryJson(entry))

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -1135,17 +1135,20 @@ export class WorkspaceService {
   // it (true -> 0, false -> -1) and drop the flag so the imported structure
   // matches the current model. A profile that already carries `order` keeps it.
   private static normalizeLegacyProfileOrder(metadata: UnitMetadataValues): UnitMetadataValues {
+    if (!metadata || typeof metadata !== 'object') return metadata;
     const mapProfile = (profile: ProfileValues & { isCurrent?: boolean }): ProfileValues => {
       const { isCurrent, ...rest } = profile;
       return { ...rest, order: profile.order ?? orderFromCurrent(!!isCurrent) };
     };
     return {
       ...metadata,
-      profiles: metadata.profiles?.map(mapProfile),
-      items: metadata.items?.map(item => ({
-        ...item,
-        profiles: item.profiles?.map(mapProfile)
-      }))
+      ...(metadata.profiles && { profiles: metadata.profiles.map(mapProfile) }),
+      ...(metadata.items && {
+        items: metadata.items.map(item => ({
+          ...item,
+          ...(item.profiles && { profiles: item.profiles.map(mapProfile) })
+        }))
+      })
     };
   }
 

--- a/apps/frontend-e2e/src/support/metadata/metadata-util.ts
+++ b/apps/frontend-e2e/src/support/metadata/metadata-util.ts
@@ -188,8 +188,6 @@ export function getItem(profile: string, moreThanOne: boolean, copyItem?: string
       cy.get(`mat-expansion-panel:contains("${json.metadata['without-id']}")`).click();
       cy.get('mat-label:contains("Item ID")')
         .eq(-1).type(IqbProfileExamples.get(profile).get('Item ID'));
-      cy.get(`mat-label:contains("${json.metadata.weighting}")`)
-        .eq(-1).type(IqbProfileExamples.get(profile).get('Wichtung'));
       cy.get(`mat-label:contains("${json.metadata.description}")`)
         .eq(-1).type(IqbProfileExamples.get(profile).get('Notiz'));
     });
@@ -199,8 +197,6 @@ export function getItem(profile: string, moreThanOne: boolean, copyItem?: string
       cy.get(`mat-expansion-panel:contains("${json.metadata['without-id']}")`).click();
       cy.get('mat-label:contains("Item ID")')
         .eq(-1).type(IqbProfileExamples.get(profile).get('Item ID'));
-      cy.get(`mat-label:contains("${json.metadata.weighting}")`)
-        .eq(-1).type(IqbProfileExamples.get(profile).get('Wichtung'));
       cy.get(`mat-label:contains("${json.metadata.description}")`)
         .eq(-1).type(IqbProfileExamples.get(profile).get('Notiz'));
     });

--- a/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.html
+++ b/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.html
@@ -1,6 +1,6 @@
 @for (profile of profiles; track profile) {
   <div class="profiles">
-    @if (profile.isCurrent) {
+    @if (profile.order | isCurrentProfile) {
       @for (entry of profile.entries; track entry) {
         <div class="fx-row-space-between-start">
           <span class="item-key">{{ entry.label[0].value }}</span>

--- a/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.spec.ts
+++ b/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.spec.ts
@@ -3,6 +3,7 @@ import { ProfileValues } from '@studio-lite-lib/api-dto';
 import { MetadataProfileEntriesComponent } from './metadata-profile-entries.component';
 import { IsArrayPipe } from '../../pipes/is-array.pipe';
 import { CastPipe } from '../../pipes/cast.pipe';
+import { IsCurrentProfilePipe } from '../../pipes/is-current-profile.pipe';
 
 describe('MetadataProfileEntriesComponent', () => {
   let component: MetadataProfileEntriesComponent;
@@ -11,7 +12,7 @@ describe('MetadataProfileEntriesComponent', () => {
   const mockProfiles: ProfileValues[] = [
     {
       profileId: 'profile1',
-      isCurrent: true,
+      order: 0,
       entries: [
         {
           id: 'entry1',
@@ -44,7 +45,7 @@ describe('MetadataProfileEntriesComponent', () => {
     },
     {
       profileId: 'profile2',
-      isCurrent: false,
+      order: -1,
       entries: [
         {
           id: 'entry5',
@@ -61,7 +62,8 @@ describe('MetadataProfileEntriesComponent', () => {
       imports: [
         MetadataProfileEntriesComponent,
         IsArrayPipe,
-        CastPipe
+        CastPipe,
+        IsCurrentProfilePipe
       ]
     }).compileComponents();
 

--- a/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.ts
+++ b/apps/frontend/src/app/components/metadata-profile-entries/metadata-profile-entries.component.ts
@@ -3,6 +3,7 @@ import { ProfileValues } from '@studio-lite-lib/api-dto';
 import { LanguageCodedText as TextWithLanguage } from '@iqbspecs/metadata-profile';
 import { IsArrayPipe } from '../../pipes/is-array.pipe';
 import { CastPipe } from '../../pipes/cast.pipe';
+import { IsCurrentProfilePipe } from '../../pipes/is-current-profile.pipe';
 
 @Component({
   selector: 'studio-lite-metadata-profile-entries',
@@ -10,7 +11,8 @@ import { CastPipe } from '../../pipes/cast.pipe';
   styleUrls: ['./metadata-profile-entries.component.scss'],
   imports: [
     IsArrayPipe,
-    CastPipe
+    CastPipe,
+    IsCurrentProfilePipe
   ]
 })
 export class MetadataProfileEntriesComponent {

--- a/apps/frontend/src/app/components/metadata-readonly-items/metadata-readonly-items.component.spec.ts
+++ b/apps/frontend/src/app/components/metadata-readonly-items/metadata-readonly-items.component.spec.ts
@@ -41,7 +41,7 @@ describe('MetadataReadonlyItemsComponent', () => {
       variableReadOnlyId: 'ro-var-1',
       weighting: 1.5,
       description: 'Test Item 1',
-      profiles: [{ profileId: 'p1', isCurrent: true, entries: [] }]
+      profiles: [{ profileId: 'p1', order: 0, entries: [] }]
     },
     {
       id: '',

--- a/apps/frontend/src/app/modules/metadata/components/item/item.component.ts
+++ b/apps/frontend/src/app/modules/metadata/components/item/item.component.ts
@@ -120,16 +120,6 @@ export class ItemComponent implements OnInit, OnChanges, OnDestroy {
             }
           },
           {
-            type: 'input',
-            key: 'weighting',
-            props: {
-              type: 'number',
-              min: 0,
-              placeholder: this.translateService.instant('metadata.weighting'),
-              label: this.translateService.instant('metadata.weighting')
-            }
-          },
-          {
             type: 'textarea',
             key: 'description',
             props: {
@@ -163,7 +153,6 @@ export class ItemComponent implements OnInit, OnChanges, OnDestroy {
   private initModel(): void {
     if (this.metadata[this.itemIndex].id) this.model.id = this.metadata[this.itemIndex].id;
     if (this.metadata[this.itemIndex].description) this.model.description = this.metadata[this.itemIndex].description;
-    if (this.metadata[this.itemIndex].weighting) this.model.weighting = this.metadata[this.itemIndex].weighting;
     this.updateModelVariableId();
   }
 

--- a/apps/frontend/src/app/modules/metadata/components/items/items.component.spec.ts
+++ b/apps/frontend/src/app/modules/metadata/components/items/items.component.spec.ts
@@ -117,12 +117,12 @@ describe('ItemsComponent', () => {
       profiles: [
         {
           profileId: 'test-profile-url',
-          isCurrent: false, // fallback will match with workspaceSettings.itemMDProfile
+          order: -1, // fallback will match with workspaceSettings.itemMDProfile
           entries: [{ id: 'entry1', value: 'value1' }]
         },
         {
           profileId: 'other-profile-url',
-          isCurrent: false,
+          order: -1,
           entries: [{ id: 'entry2', value: 'value2' }]
         }
       ]
@@ -140,16 +140,16 @@ describe('ItemsComponent', () => {
     expect(copiedItem.profiles).toBeDefined();
     expect(copiedItem.profiles?.length).toBe(2);
 
-    // Current profile: metadata entries copied, isCurrent set to true
+    // Current profile: metadata entries copied, order set to 0 (active)
     const currentProfile = copiedItem.profiles?.[0];
     expect(currentProfile?.profileId).toBe('test-profile-url');
-    expect(currentProfile?.isCurrent).toBe(true);
+    expect(currentProfile?.order).toBe(0);
     expect(currentProfile?.entries).toEqual([{ id: 'entry1', value: 'value1' }]);
 
-    // Non-current profile: metadata entries cleared, profileId preserved, isCurrent false
+    // Non-current profile: metadata entries cleared, profileId preserved, order -1 (hidden)
     const nonCurrentProfile = copiedItem.profiles?.[1];
     expect(nonCurrentProfile?.profileId).toBe('other-profile-url');
-    expect(nonCurrentProfile?.isCurrent).toBe(false);
+    expect(nonCurrentProfile?.order).toBe(-1);
     expect(nonCurrentProfile?.entries).toEqual([]);
 
     expect(emitSpy).toHaveBeenCalled();

--- a/apps/frontend/src/app/modules/metadata/components/items/items.component.ts
+++ b/apps/frontend/src/app/modules/metadata/components/items/items.component.ts
@@ -12,7 +12,9 @@ import { MatIconButton, MatButton } from '@angular/material/button';
 import { ItemsMetadataValues, ProfileMetadataValues, UnitMetadataValues } from '@studio-lite-lib/api-dto';
 import { MatDialog } from '@angular/material/dialog';
 import { MDProfile } from '@iqbspecs/metadata-profile';
-import { profileIdsMatch } from '@studio-lite/shared-code';
+import {
+  ACTIVE_PROFILE_ORDER, HIDDEN_PROFILE_ORDER, isCurrentFromOrder, profileIdsMatch
+} from '@studio-lite/shared-code';
 import { FormsModule } from '@angular/forms';
 import { WrappedIconComponent } from '../../../../components/wrapped-icon/wrapped-icon.component';
 import { ItemComponent } from '../item/item.component';
@@ -141,10 +143,11 @@ export class ItemsComponent implements OnInit, OnChanges, OnDestroy {
         const currentProfileId = this.workspaceService.workspaceSettings?.itemMDProfile;
         item.profiles = item.profiles
           .map(profile => {
-            const isCurrent = profile.isCurrent || profileIdsMatch(profile.profileId, currentProfileId);
+            const isCurrent = isCurrentFromOrder(profile.order) ||
+              profileIdsMatch(profile.profileId, currentProfileId);
             return isCurrent ?
-              { ...profile, id: undefined, isCurrent: true } :
-              { profileId: profile.profileId, isCurrent: false, entries: [] };
+              { ...profile, id: undefined, order: ACTIVE_PROFILE_ORDER } :
+              { profileId: profile.profileId, order: HIDDEN_PROFILE_ORDER, entries: [] };
           });
       }
       this.addItem({

--- a/apps/frontend/src/app/modules/metadata/components/items/items.component.ts
+++ b/apps/frontend/src/app/modules/metadata/components/items/items.component.ts
@@ -155,11 +155,8 @@ export class ItemsComponent implements OnInit, OnChanges, OnDestroy {
         id: undefined,
         uuid: undefined,
         order: undefined,
-        position: undefined,
-        locked: undefined,
         variableId: undefined,
         variableReadOnlyId: undefined,
-        weighting: undefined,
         description: undefined,
         createdAt: undefined,
         changedAt: undefined

--- a/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.spec.ts
+++ b/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.spec.ts
@@ -113,7 +113,7 @@ describe('TableViewComponent', () => {
       id: 1,
       key: 'K1',
       metadata: {
-        profiles: [{ isCurrent: true, entries: [{ label, valueAsText: { value: '42' } }] }]
+        profiles: [{ order: 0, entries: [{ label, valueAsText: { value: '42' } }] }]
       }
     } as unknown as UnitPropertiesDto;
 

--- a/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.ts
+++ b/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.ts
@@ -15,6 +15,7 @@ import {
   MatHeaderRow, MatRowDef, MatRow, MatTableDataSource
 } from '@angular/material/table';
 import { ItemsMetadataValues, MetadataValuesEntry, UnitPropertiesDto } from '@studio-lite-lib/api-dto';
+import { isCurrentFromOrder } from '@studio-lite/shared-code';
 import { MetadataResolver } from '@iqb/metadata-resolver';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
@@ -126,7 +127,7 @@ export class TableViewComponent implements OnInit {
       if (unit.metadata && unit.metadata.items) {
         unit.metadata.items.forEach((item, i: number) => {
           const activeProfile = item.profiles?.find(
-            profile => profile.isCurrent
+            profile => isCurrentFromOrder(profile.order)
           );
           if (activeProfile && activeProfile.entries) {
             let values: ColumnValues = {};
@@ -201,7 +202,7 @@ export class TableViewComponent implements OnInit {
     units.forEach(unit => {
       const activeProfile =
         unit.metadata &&
-        unit.metadata.profiles?.find(profile => profile.isCurrent);
+        unit.metadata.profiles?.find(profile => isCurrentFromOrder(profile.order));
       if (activeProfile) {
         let values: ColumnValues = {};
         if (activeProfile.entries) {

--- a/apps/frontend/src/app/modules/metadata/models/item-model.interface.ts
+++ b/apps/frontend/src/app/modules/metadata/models/item-model.interface.ts
@@ -3,6 +3,5 @@ export interface ItemModel {
   variableId?: string | null;
   variableReadOnlyId?: string | null;
   description?: string;
-  weighting?: number;
   [key: string]: string | number | null | undefined;
 }

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
@@ -161,4 +161,19 @@ describe('UnitPropertiesComponent', () => {
       items: [{ id: 'new' }]
     });
   });
+
+  it('does not clobber stored profiles when onMetadataChange carries no profiles slice', () => {
+    const store = createMock<UnitMetadataStore>();
+    store.getData.mockReturnValue({
+      metadata: { profiles: [{ profileId: 'p1' }], items: [{ id: 'item1' }] }
+    } as unknown as UnitPropertiesDto);
+    jest.spyOn(component.workspaceService, 'getUnitMetadataStore').mockReturnValue(store);
+
+    component.onMetadataChange({} as unknown as Parameters<typeof component.onMetadataChange>[0]);
+
+    expect(store.setMetadata).toHaveBeenCalledWith({
+      profiles: [{ profileId: 'p1' }],
+      items: [{ id: 'item1' }]
+    });
+  });
 });

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
@@ -5,7 +5,10 @@ import { Component, Input } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
+import { createMock } from '@golevelup/ts-jest';
 import { WorkspaceSettingsDto } from '@studio-lite-lib/api-dto';
+import { UnitMetadataValues as IqbUnitMetadataValues } from '@iqb/metadata-components';
+import { UnitMetadataStore } from '../../classes/unit-metadata-store';
 import { ModuleService } from '../../../../services/module.service';
 import { WorkspaceBackendService } from '../../services/workspace-backend.service';
 import { WorkspaceService } from '../../services/workspace.service';
@@ -127,5 +130,42 @@ describe('UnitPropertiesComponent', () => {
     component.onGroupNameChange('Group A');
 
     expect(component.unitForm.get('group')?.value).toBe('Group A');
+  });
+
+  it('should merge profiles in onMetadataChange and call setMetadata', () => {
+    const mockStore = createMock<UnitMetadataStore>();
+    jest.spyOn(component.workspaceService, 'getUnitMetadataStore')
+      .mockReturnValue(mockStore);
+    component.metadata = {
+      profiles: [{ profileId: 'p1', entries: [] }],
+      items: [{ id: 'item1', profiles: [] }]
+    };
+
+    component.onMetadataChange(createMock<IqbUnitMetadataValues>({
+      profiles: [{ profileId: 'p2', entries: [] }]
+    }));
+
+    expect(component.metadata.profiles).toEqual([{ profileId: 'p2', entries: [] }]);
+    expect(component.metadata.items).toEqual([{ id: 'item1', profiles: [] }]);
+    expect(mockStore.setMetadata).toHaveBeenCalledWith(component.metadata);
+  });
+
+  it('should merge items in onItemsMetadataChange and call setMetadata', () => {
+    const mockStore = createMock<UnitMetadataStore>();
+    jest.spyOn(component.workspaceService, 'getUnitMetadataStore')
+      .mockReturnValue(mockStore);
+    component.metadata = {
+      profiles: [{ profileId: 'p1', entries: [] }],
+      items: [{ id: 'item1', profiles: [] }]
+    };
+
+    component.onItemsMetadataChange({
+      profiles: [],
+      items: [{ id: 'item2', profiles: [] }]
+    });
+
+    expect(component.metadata.profiles).toEqual([{ profileId: 'p1', entries: [] }]);
+    expect(component.metadata.items).toEqual([{ id: 'item2', profiles: [] }]);
+    expect(mockStore.setMetadata).toHaveBeenCalledWith(component.metadata);
   });
 });

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.spec.ts
@@ -6,8 +6,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { createMock } from '@golevelup/ts-jest';
-import { WorkspaceSettingsDto } from '@studio-lite-lib/api-dto';
-import { UnitMetadataValues as IqbUnitMetadataValues } from '@iqb/metadata-components';
+import { UnitMetadataValues, UnitPropertiesDto, WorkspaceSettingsDto } from '@studio-lite-lib/api-dto';
 import { UnitMetadataStore } from '../../classes/unit-metadata-store';
 import { ModuleService } from '../../../../services/module.service';
 import { WorkspaceBackendService } from '../../services/workspace-backend.service';
@@ -132,40 +131,34 @@ describe('UnitPropertiesComponent', () => {
     expect(component.unitForm.get('group')?.value).toBe('Group A');
   });
 
-  it('should merge profiles in onMetadataChange and call setMetadata', () => {
-    const mockStore = createMock<UnitMetadataStore>();
-    jest.spyOn(component.workspaceService, 'getUnitMetadataStore')
-      .mockReturnValue(mockStore);
-    component.metadata = {
-      profiles: [{ profileId: 'p1', entries: [] }],
-      items: [{ id: 'item1', profiles: [] }]
-    };
+  it('merges changed profiles into the store while preserving items', () => {
+    const store = createMock<UnitMetadataStore>();
+    store.getData.mockReturnValue({
+      metadata: { profiles: [{ profileId: 'old' }], items: [{ id: 'item1' }] }
+    } as unknown as UnitPropertiesDto);
+    jest.spyOn(component.workspaceService, 'getUnitMetadataStore').mockReturnValue(store);
 
-    component.onMetadataChange(createMock<IqbUnitMetadataValues>({
-      profiles: [{ profileId: 'p2', entries: [] }]
-    }));
+    component.onMetadataChange({ profiles: [{ profileId: 'new' }] } as unknown as Parameters<
+    typeof component.onMetadataChange>[0]);
 
-    expect(component.metadata.profiles).toEqual([{ profileId: 'p2', entries: [] }]);
-    expect(component.metadata.items).toEqual([{ id: 'item1', profiles: [] }]);
-    expect(mockStore.setMetadata).toHaveBeenCalledWith(component.metadata);
+    expect(store.setMetadata).toHaveBeenCalledWith({
+      profiles: [{ profileId: 'new' }],
+      items: [{ id: 'item1' }]
+    });
   });
 
-  it('should merge items in onItemsMetadataChange and call setMetadata', () => {
-    const mockStore = createMock<UnitMetadataStore>();
-    jest.spyOn(component.workspaceService, 'getUnitMetadataStore')
-      .mockReturnValue(mockStore);
-    component.metadata = {
-      profiles: [{ profileId: 'p1', entries: [] }],
-      items: [{ id: 'item1', profiles: [] }]
-    };
+  it('merges changed items into the store while preserving profiles', () => {
+    const store = createMock<UnitMetadataStore>();
+    store.getData.mockReturnValue({
+      metadata: { profiles: [{ profileId: 'p1' }], items: [{ id: 'old' }] }
+    } as unknown as UnitPropertiesDto);
+    jest.spyOn(component.workspaceService, 'getUnitMetadataStore').mockReturnValue(store);
 
-    component.onItemsMetadataChange({
-      profiles: [],
-      items: [{ id: 'item2', profiles: [] }]
+    component.onItemsMetadataChange({ profiles: [], items: [{ id: 'new' }] } as unknown as UnitMetadataValues);
+
+    expect(store.setMetadata).toHaveBeenCalledWith({
+      profiles: [{ profileId: 'p1' }],
+      items: [{ id: 'new' }]
     });
-
-    expect(component.metadata.profiles).toEqual([{ profileId: 'p1', entries: [] }]);
-    expect(component.metadata.items).toEqual([{ id: 'item2', profiles: [] }]);
-    expect(mockStore.setMetadata).toHaveBeenCalledWith(component.metadata);
   });
 });

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
@@ -11,7 +11,6 @@ import {
   BehaviorSubject, Subject, Subscription, takeUntil
 } from 'rxjs';
 import {
-  UnitMetadataDto,
   UnitMetadataValues,
   UnitPropertiesDto,
   WorkspaceSettingsDto
@@ -451,20 +450,23 @@ export class UnitPropertiesComponent
     return [];
   }
 
+  // Profiles and items are edited by two independent child components. Each change
+  // must update only its own slice of the stored metadata: merging into the store's
+  // current value (rather than replacing it, or rebuilding `this.metadata` which
+  // would retrigger the items editor and drop in-flight item edits) keeps both the
+  // unit profiles and the item metadata when either side changes.
   onMetadataChange(metadata: Partial<IqbUnitMetadataValues>): void {
-    this.metadata = {
-      ...this.metadata,
-      profiles: metadata.profiles as unknown as UnitMetadataDto[]
-    };
-    this.workspaceService.getUnitMetadataStore()?.setMetadata(this.metadata);
+    const store = this.workspaceService.getUnitMetadataStore();
+    if (!store) return;
+    const current = (store.getData().metadata ?? {}) as UnitMetadataValues;
+    store.setMetadata({ ...current, profiles: metadata.profiles as unknown as UnitMetadataValues['profiles'] });
   }
 
   onItemsMetadataChange(metadata: UnitMetadataValues): void {
-    this.metadata = {
-      ...this.metadata,
-      items: metadata.items || []
-    };
-    this.workspaceService.getUnitMetadataStore()?.setMetadata(this.metadata);
+    const store = this.workspaceService.getUnitMetadataStore();
+    if (!store) return;
+    const current = (store.getData().metadata ?? {}) as UnitMetadataValues;
+    store.setMetadata({ ...current, items: metadata.items || [] });
   }
 
   onGroupNameChange(name: string): void {

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
@@ -11,6 +11,7 @@ import {
   BehaviorSubject, Subject, Subscription, takeUntil
 } from 'rxjs';
 import {
+  UnitMetadataDto,
   UnitMetadataValues,
   UnitPropertiesDto,
   WorkspaceSettingsDto
@@ -451,11 +452,19 @@ export class UnitPropertiesComponent
   }
 
   onMetadataChange(metadata: Partial<IqbUnitMetadataValues>): void {
-    this.workspaceService.getUnitMetadataStore()?.setMetadata(metadata as unknown as UnitMetadataValues);
+    this.metadata = {
+      ...this.metadata,
+      profiles: metadata.profiles as unknown as UnitMetadataDto[]
+    };
+    this.workspaceService.getUnitMetadataStore()?.setMetadata(this.metadata);
   }
 
   onItemsMetadataChange(metadata: UnitMetadataValues): void {
-    this.workspaceService.getUnitMetadataStore()?.setMetadata(metadata);
+    this.metadata = {
+      ...this.metadata,
+      items: metadata.items || []
+    };
+    this.workspaceService.getUnitMetadataStore()?.setMetadata(this.metadata);
   }
 
   onGroupNameChange(name: string): void {

--- a/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/unit-properties/unit-properties.component.ts
@@ -459,14 +459,23 @@ export class UnitPropertiesComponent
     const store = this.workspaceService.getUnitMetadataStore();
     if (!store) return;
     const current = (store.getData().metadata ?? {}) as UnitMetadataValues;
-    store.setMetadata({ ...current, profiles: metadata.profiles as unknown as UnitMetadataValues['profiles'] });
+    // Only overwrite the profiles slice when the event actually carries one, so a
+    // profiles-less emit can never clobber the stored profiles (an empty array is
+    // a deliberate "clear", undefined is not).
+    store.setMetadata({
+      ...current,
+      ...(metadata.profiles && { profiles: metadata.profiles as unknown as UnitMetadataValues['profiles'] })
+    });
   }
 
   onItemsMetadataChange(metadata: UnitMetadataValues): void {
     const store = this.workspaceService.getUnitMetadataStore();
     if (!store) return;
     const current = (store.getData().metadata ?? {}) as UnitMetadataValues;
-    store.setMetadata({ ...current, items: metadata.items || [] });
+    store.setMetadata({
+      ...current,
+      ...(metadata.items && { items: metadata.items })
+    });
   }
 
   onGroupNameChange(name: string): void {

--- a/apps/frontend/src/app/pipes/is-current-profile.pipe.spec.ts
+++ b/apps/frontend/src/app/pipes/is-current-profile.pipe.spec.ts
@@ -11,12 +11,12 @@ describe('IsCurrentProfilePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('should return true for a visible profile (order 0)', () => {
+  it('should return true for the primary profile (order 0)', () => {
     expect(pipe.transform(0)).toBe(true);
   });
 
-  it('should return true for any non-negative order (position)', () => {
-    expect(pipe.transform(2)).toBe(true);
+  it('should return false for a visible non-primary position (order > 0)', () => {
+    expect(pipe.transform(2)).toBe(false);
   });
 
   it('should return false for a hidden profile (order -1)', () => {

--- a/apps/frontend/src/app/pipes/is-current-profile.pipe.spec.ts
+++ b/apps/frontend/src/app/pipes/is-current-profile.pipe.spec.ts
@@ -1,0 +1,30 @@
+import { IsCurrentProfilePipe } from './is-current-profile.pipe';
+
+describe('IsCurrentProfilePipe', () => {
+  let pipe: IsCurrentProfilePipe;
+
+  beforeEach(() => {
+    pipe = new IsCurrentProfilePipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return true for a visible profile (order 0)', () => {
+    expect(pipe.transform(0)).toBe(true);
+  });
+
+  it('should return true for any non-negative order (position)', () => {
+    expect(pipe.transform(2)).toBe(true);
+  });
+
+  it('should return false for a hidden profile (order -1)', () => {
+    expect(pipe.transform(-1)).toBe(false);
+  });
+
+  it('should treat null/undefined as hidden', () => {
+    expect(pipe.transform(null)).toBe(false);
+    expect(pipe.transform(undefined)).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/pipes/is-current-profile.pipe.ts
+++ b/apps/frontend/src/app/pipes/is-current-profile.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isCurrentFromOrder } from '@studio-lite/shared-code';
+
+@Pipe({
+  name: 'isCurrentProfile',
+  standalone: true
+})
+export class IsCurrentProfilePipe implements PipeTransform {
+  // eslint-disable-next-line class-methods-use-this
+  transform(order: number | null | undefined): boolean {
+    return isCurrentFromOrder(order);
+  }
+}

--- a/database/changelog/studio-lite.changelog-18.0.0.sql
+++ b/database/changelog/studio-lite.changelog-18.0.0.sql
@@ -39,3 +39,21 @@ UPDATE "public"."unit"
   SET "uuid" = gen_random_uuid()::VARCHAR
   WHERE "uuid" IS NULL;
 -- rollback UPDATE "public"."unit" SET "uuid" = NULL;
+
+-- changeset jojohoch:7
+-- Replace the boolean "is_current" flag with the metadata-values@3.x "order"
+-- field (-1 = hidden/disabled, >= 0 = position). "order" is the single source of
+-- truth for the active/hidden profile; "isCurrent" is derived in code where the
+-- legacy XML export still needs it. The UPDATE migrates existing rows before the
+-- boolean is dropped. All statements target the parent table "metadata"; via
+-- Postgres table inheritance they propagate to "unit_metadata" and
+-- "unit_item_metadata".
+ALTER TABLE "public"."metadata"
+  ADD COLUMN "order" INTEGER NOT NULL DEFAULT -1;
+UPDATE "public"."metadata"
+  SET "order" = CASE WHEN "is_current" THEN 0 ELSE -1 END;
+ALTER TABLE "public"."metadata"
+  DROP COLUMN "is_current";
+-- rollback ALTER TABLE "public"."metadata" ADD COLUMN "is_current" BOOLEAN DEFAULT true;
+-- rollback UPDATE "public"."metadata" SET "is_current" = ("order" <> -1);
+-- rollback ALTER TABLE "public"."metadata" DROP COLUMN "order";

--- a/libs/api-dto/src/lib/dtos/metadata/metadata.dto.ts
+++ b/libs/api-dto/src/lib/dtos/metadata/metadata.dto.ts
@@ -12,7 +12,7 @@ export class MetadataDto {
     profileId?: string;
 
   @ApiProperty()
-    isCurrent?: boolean;
+    order?: number;
 
   @ApiProperty()
     createdAt?: Date;

--- a/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
+++ b/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
@@ -13,7 +13,9 @@ export class UnitMetadataValues extends ProfileMetadataValues {
 export class ProfileValues {
   entries?: MetadataValuesEntry[];
   profileId?: string;
-  isCurrent?: boolean;
+  // metadata-values@3.x profile order: -1 = hidden/disabled, >= 0 = position.
+  // Replaces the legacy `isCurrent` boolean.
+  order?: number;
 }
 
 export class ItemsMetadataValues extends ProfileMetadataValues {

--- a/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
+++ b/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
@@ -21,8 +21,6 @@ export class ProfileValues {
 export class ItemsMetadataValues extends ProfileMetadataValues {
   uuid?: string;
   order?: number;
-  position?: string;
-  locked?: boolean;
   unitId?: number;
   createdAt?: Date;
   changedAt?: Date;

--- a/libs/shared-code/src/index.ts
+++ b/libs/shared-code/src/index.ts
@@ -2,6 +2,9 @@ export { VeronaModuleFactory } from './lib/helper/verona-module.factory';
 export { VeronaModuleKeyCollection } from './lib/helper/verona-module-key-collection.class';
 export { canonicalizeProfileId, profileIdsMatch, isItemProfileId } from './lib/profile-id';
 export {
+  HIDDEN_PROFILE_ORDER, ACTIVE_PROFILE_ORDER, orderFromCurrent, isCurrentFromOrder
+} from './lib/profile-order';
+export {
   ReconcilableProfile, ProfileReconcileOps, mergeProfile, reconcileProfilesByProfileId
 } from './lib/metadata-reconcile';
 export {

--- a/libs/shared-code/src/lib/metadata-reconcile.spec.ts
+++ b/libs/shared-code/src/lib/metadata-reconcile.spec.ts
@@ -4,7 +4,7 @@ interface TestProfile {
   id: number;
   profileId?: string;
   createdAt?: Date;
-  isCurrent?: boolean;
+  order?: number;
   entries?: string[];
 }
 
@@ -30,7 +30,7 @@ describe('mergeProfile', () => {
   it('keeps id/createdAt from the stored row and entries from the incoming payload', () => {
     const created = new Date('2020-01-01');
     const existing: TestProfile = {
-      id: 7, profileId: 'p1', createdAt: created, isCurrent: true, entries: ['old']
+      id: 7, profileId: 'p1', createdAt: created, order: 0, entries: ['old']
     };
     const incoming: TestProfile = { id: undefined as unknown as number, profileId: 'p1', entries: ['new'] };
 
@@ -39,14 +39,14 @@ describe('mergeProfile', () => {
     expect(merged.id).toBe(7);
     expect(merged.createdAt).toBe(created);
     expect(merged.entries).toEqual(['new']);
-    expect(merged.isCurrent).toBe(true); // inherited because incoming omits it
+    expect(merged.order).toBe(0); // inherited because incoming omits it
   });
 
-  it('takes isCurrent from the incoming payload when present, including false', () => {
-    const existing: TestProfile = { id: 1, profileId: 'p1', isCurrent: true };
-    const incoming: TestProfile = { id: 1, profileId: 'p1', isCurrent: false };
+  it('takes order from the incoming payload when present, including -1', () => {
+    const existing: TestProfile = { id: 1, profileId: 'p1', order: 0 };
+    const incoming: TestProfile = { id: 1, profileId: 'p1', order: -1 };
 
-    expect(mergeProfile(existing, incoming).isCurrent).toBe(false);
+    expect(mergeProfile(existing, incoming).order).toBe(-1);
   });
 });
 

--- a/libs/shared-code/src/lib/metadata-reconcile.ts
+++ b/libs/shared-code/src/lib/metadata-reconcile.ts
@@ -2,7 +2,7 @@
  * Reconciling stored metadata rows with an incoming payload.
  *
  * The metadata profile form re-emits profiles WITHOUT their persisted row id (and
- * without created_at/is_current), so the write path cannot match stored rows to
+ * without created_at/order), so the write path cannot match stored rows to
  * incoming ones by id. It matches by `profileId` instead: a unit / item holds at
  * most one metadata row per profile, so the profileId is a stable natural key.
  */
@@ -11,7 +11,7 @@ export interface ReconcilableProfile {
   id: number;
   profileId?: string;
   createdAt?: Date;
-  isCurrent?: boolean;
+  order?: number;
 }
 
 export interface ProfileReconcileOps<T> {
@@ -21,9 +21,9 @@ export interface ProfileReconcileOps<T> {
 }
 
 /**
- * Carry identity, creation time and the current-profile flag over from the stored
- * row; take everything else (entries/values) from the incoming payload. `isCurrent`
- * is only inherited when the incoming payload omits it.
+ * Carry identity, creation time and the profile `order` over from the stored row;
+ * take everything else (entries/values) from the incoming payload. `order` is only
+ * inherited when the incoming payload omits it.
  */
 export function mergeProfile<T extends ReconcilableProfile>(existing: T, incoming: T): T {
   return {
@@ -31,7 +31,7 @@ export function mergeProfile<T extends ReconcilableProfile>(existing: T, incomin
     ...incoming,
     id: existing.id,
     createdAt: existing.createdAt,
-    isCurrent: incoming.isCurrent ?? existing.isCurrent
+    order: incoming.order ?? existing.order
   };
 }
 

--- a/libs/shared-code/src/lib/profile-order.spec.ts
+++ b/libs/shared-code/src/lib/profile-order.spec.ts
@@ -16,9 +16,12 @@ describe('profile-order', () => {
   });
 
   describe('isCurrentFromOrder', () => {
-    it('treats order 0 (and any non-negative position) as current', () => {
+    it('treats only order 0 (the primary profile) as current', () => {
       expect(isCurrentFromOrder(0)).toBe(true);
-      expect(isCurrentFromOrder(3)).toBe(true);
+    });
+
+    it('treats a visible but non-primary position (order > 0) as not current', () => {
+      expect(isCurrentFromOrder(3)).toBe(false);
     });
 
     it('treats order -1 as not current (hidden)', () => {

--- a/libs/shared-code/src/lib/profile-order.spec.ts
+++ b/libs/shared-code/src/lib/profile-order.spec.ts
@@ -1,0 +1,33 @@
+import {
+  ACTIVE_PROFILE_ORDER, HIDDEN_PROFILE_ORDER, isCurrentFromOrder, orderFromCurrent
+} from './profile-order';
+
+describe('profile-order', () => {
+  describe('orderFromCurrent', () => {
+    it('maps the active profile to order 0', () => {
+      expect(orderFromCurrent(true)).toBe(ACTIVE_PROFILE_ORDER);
+      expect(orderFromCurrent(true)).toBe(0);
+    });
+
+    it('maps a non-active profile to order -1 (hidden)', () => {
+      expect(orderFromCurrent(false)).toBe(HIDDEN_PROFILE_ORDER);
+      expect(orderFromCurrent(false)).toBe(-1);
+    });
+  });
+
+  describe('isCurrentFromOrder', () => {
+    it('treats order 0 (and any non-negative position) as current', () => {
+      expect(isCurrentFromOrder(0)).toBe(true);
+      expect(isCurrentFromOrder(3)).toBe(true);
+    });
+
+    it('treats order -1 as not current (hidden)', () => {
+      expect(isCurrentFromOrder(-1)).toBe(false);
+    });
+
+    it('treats null/undefined as not current', () => {
+      expect(isCurrentFromOrder(null)).toBe(false);
+      expect(isCurrentFromOrder(undefined)).toBe(false);
+    });
+  });
+});

--- a/libs/shared-code/src/lib/profile-order.ts
+++ b/libs/shared-code/src/lib/profile-order.ts
@@ -1,0 +1,22 @@
+/**
+ * The metadata-values@3.x `order` field replaces the legacy boolean `isCurrent`
+ * flag as the single representation of a profile's state:
+ *
+ *   order = -1   -> hidden/disabled (the former `isCurrent: false`)
+ *   order >=  0  -> visible; the value is the position when several profiles are
+ *                   used. Today a unit/item has at most one visible profile, so
+ *                   the active one is `order: 0`.
+ *
+ * `isCurrent` is no longer persisted; where the legacy XML export still speaks in
+ * terms of "the current profile", it is derived from `order` via these helpers.
+ */
+export const HIDDEN_PROFILE_ORDER = -1;
+export const ACTIVE_PROFILE_ORDER = 0;
+
+export function orderFromCurrent(isCurrent: boolean): number {
+  return isCurrent ? ACTIVE_PROFILE_ORDER : HIDDEN_PROFILE_ORDER;
+}
+
+export function isCurrentFromOrder(order: number | null | undefined): boolean {
+  return (order ?? HIDDEN_PROFILE_ORDER) !== HIDDEN_PROFILE_ORDER;
+}

--- a/libs/shared-code/src/lib/profile-order.ts
+++ b/libs/shared-code/src/lib/profile-order.ts
@@ -4,11 +4,12 @@
  *
  *   order = -1   -> hidden/disabled (the former `isCurrent: false`)
  *   order >=  0  -> visible; the value is the position when several profiles are
- *                   used. Today a unit/item has at most one visible profile, so
- *                   the active one is `order: 0`.
+ *                   used. The profile at position 0 is the current/primary one.
  *
- * `isCurrent` is no longer persisted; where the legacy XML export still speaks in
- * terms of "the current profile", it is derived from `order` via these helpers.
+ * `isCurrent` is no longer persisted. `isCurrentFromOrder` is the faithful
+ * replacement of the legacy boolean: legacy data had exactly one current profile,
+ * which maps to `order: 0` — a visible-but-non-primary profile (order > 0, only
+ * possible once multiple profiles are supported) is NOT "the current one".
  */
 export const HIDDEN_PROFILE_ORDER = -1;
 export const ACTIVE_PROFILE_ORDER = 0;
@@ -18,5 +19,5 @@ export function orderFromCurrent(isCurrent: boolean): number {
 }
 
 export function isCurrentFromOrder(order: number | null | undefined): boolean {
-  return (order ?? HIDDEN_PROFILE_ORDER) !== HIDDEN_PROFILE_ORDER;
+  return order === ACTIVE_PROFILE_ORDER;
 }


### PR DESCRIPTION
Setzt die metadata-values@3.x-Spec im Metadaten-Handling vollständiger um und behebt dabei mehrere (teils vorbestehende) Bugs. Baut auf develop auf; enthält zwei bewusst übernommene Commits aus `feature/cy-metadata` (createdAt-Fix, initial Frontend-Merge — letzterer hier korrigiert).

## Kernänderungen

**`order` ersetzt `is_current`** (metadata-values@3.x)
- DB-Migration `changelog-18.0.0` (changeset :7): `order INTEGER NOT NULL DEFAULT -1`, Backfill aus `is_current`, `is_current` gedroppt — auf Parent-Tabelle `metadata`, propagiert via Table-Inheritance. Real gegen Postgres inkl. Rollback verifiziert.
- Entity/DTO auf `order`; shared-code-Helper `orderFromCurrent`/`isCurrentFromOrder` (= primäres Profil, `order === 0`).
- Write-Pfad, reconcile, JSON-Export (emittiert `order`), XML-Export (leitet aktiv aus `order` ab), Import (Legacy-`isCurrent`→`order` normalisiert), Frontend (Pure Pipe) angepasst.

**`valueAsText`-Backfill** für Einträge ohne Anzeigetext (Lese-/Exportpfad, mutationsfrei).

**Aktuelles Profil beim Speichern korrekt flaggen** (`patchMetadata` leitet `order` aus Workspace-Settings ab) — behebt „gerade gespeichertes Profil wird als versteckt gelesen".

**Spec-Wertformen im Export** (vorbestehender Bug): das Formular speichert Werte in Spec-Form (Vokabular `{id,label}`, Simple `{raw,asText}`); Export/valueAsText hingen an der Alt-Form → form-editierte Boolean/Number fielen aus dem JSON-Export, Vokabular-Labels gingen verloren. Beide Mapper jetzt tolerant für Spec- **und** Alt-Form.

**Metadaten-Merge korrekt** (`unit-properties`): Merge am Store statt `this.metadata` neu aufzubauen — behebt Item-Datenverlust (uuid/variableId) beim Speichern; bewahrt Profile **und** Items.

**Deprecated-Feld-Bereinigung**: `weighting`-Editor-Feld / `position` / `locked` aus der Metadaten-Fläche entfernt (in keiner IQB-Spec). DB-Spalten + XML-„Wichtung" bewusst behalten, keine Migration.

## Verifikation
- Unit-Tests grün (api, frontend, shared-code, iqb-components)
- **Alle Metadaten-e2e-Specs grün** (insert-record, insert-record-admin, profile-check, variable-coding)
- Builds + Lint grün
- DB-Migration + Backfill real gegen Postgres geprüft

## Offen / Nachgelagert
- **`annotation`** (metadata-values-Feld) bleibt bewusst offen — Semantik unterspezifiziert, wird mit den Spec-Ownern geklärt, bevor gebaut wird.

## Hinweis zur Historie
Enthält einen fehlerhaften Cherry-Pick (`86328860`), der durch `395623d3` korrigiert wird — beim Merge idealerweise **squashen**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)