### PR TITLE
feat: persist and display vocabulary annotation (numbering)

### DIFF
--- a/apps/api/src/app/classes/metadata-value.util.spec.ts
+++ b/apps/api/src/app/classes/metadata-value.util.spec.ts
@@ -1,0 +1,33 @@
+import { combineNotationAndLabel } from './metadata-value.util';
+
+describe('combineNotationAndLabel', () => {
+  it('prepends the notation to each label per language', () => {
+    const result = combineNotationAndLabel(
+      [{ lang: 'de', value: '1.2' }],
+      [{ lang: 'de', value: 'Foo' }, { lang: 'en', value: 'Bar' }]
+    );
+    expect(result).toEqual([
+      { lang: 'de', value: '1.2 Foo' },
+      { lang: 'en', value: '1.2 Bar' }
+    ]);
+  });
+
+  it('returns the labels unchanged when there is no notation', () => {
+    const labels = [{ lang: 'de', value: 'Foo' }];
+    expect(combineNotationAndLabel([], labels)).toEqual(labels);
+    expect(combineNotationAndLabel(undefined, labels)).toEqual(labels);
+  });
+
+  it('returns an empty list when there is no label', () => {
+    expect(combineNotationAndLabel([{ lang: 'de', value: '1.2' }], undefined)).toEqual([]);
+    expect(combineNotationAndLabel([{ lang: 'de', value: '1.2' }], [])).toEqual([]);
+  });
+
+  it('uses the first notation entry as the numbering', () => {
+    const result = combineNotationAndLabel(
+      [{ lang: 'de', value: '1.2' }, { lang: 'en', value: '1.2' }],
+      [{ lang: 'de', value: 'Foo' }]
+    );
+    expect(result).toEqual([{ lang: 'de', value: '1.2 Foo' }]);
+  });
+});

--- a/apps/api/src/app/classes/metadata-value.util.ts
+++ b/apps/api/src/app/classes/metadata-value.util.ts
@@ -1,0 +1,16 @@
+import { LanguageCodedText } from '@iqbspecs/metadata-profile';
+
+// Builds the display text of a vocabulary entry from its numbering and label.
+// In metadata-values@3.x the spec field `annotation` holds the numbering (the
+// vocabulary's SKOS notation) and `label` the pure term. The numbering is
+// prepended per language, mirroring what the profile form renders when
+// hideNumbering is off. Returns the labels unchanged when no numbering exists.
+export function combineNotationAndLabel(
+  annotation: LanguageCodedText[] | undefined,
+  label: LanguageCodedText[] | undefined
+): LanguageCodedText[] {
+  const labels = label ?? [];
+  const notation = annotation?.[0]?.value ?? '';
+  if (!notation) return labels;
+  return labels.map(text => ({ lang: text.lang, value: `${notation} ${text.value}`.trim() }));
+}

--- a/apps/api/src/app/classes/unit-download.class.spec.ts
+++ b/apps/api/src/app/classes/unit-download.class.spec.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import {
   ItemsMetadataValues,
   ProfileValues,
+  UnitMetadataValues,
   UnitCommentDto,
   UnitDownloadBookletSettingsDto,
   UnitDownloadSettingsDto,
@@ -1127,6 +1128,28 @@ describe('UnitDownloadClass', () => {
       }]);
     });
 
+    it('should export the annotation (numbering) alongside the label', () => {
+      const result = UnitDownloadClass.transformProfilesToMetadataValues([{
+        profileId: 'p1',
+        entries: [{
+          id: 'w9',
+          label: [{ lang: 'de', value: 'Leitidee' }],
+          value: [{
+            id: 'https://w3id.org/iqb/vocab/l3',
+            text: [{ lang: 'de', value: 'Raum und Form' }],
+            annotation: [{ lang: 'de', value: '1.3' }]
+          }],
+          valueAsText: [{ lang: 'de', value: '1.3 Raum und Form' }]
+        }]
+      }] as unknown as ProfileValues[]);
+
+      expect(result[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        label: [{ lang: 'de', value: 'Raum und Form' }],
+        annotation: [{ lang: 'de', value: '1.3' }]
+      }]);
+    });
+
     it('should map string values to simple_value and skip empty strings', () => {
       const result = UnitDownloadClass.transformProfilesToMetadataValues([{
         profileId: 'p1',
@@ -1237,6 +1260,177 @@ describe('UnitDownloadClass', () => {
 
     it('should return an empty array for missing items', () => {
       expect(UnitDownloadClass.transformItems(undefined)).toEqual([]);
+    });
+  });
+
+  describe('toLegacyMetadataBlob (frozen XML .vomd shape)', () => {
+    it('folds the annotation back into a form-created label and empties annotation', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 'w1',
+            label: [{ lang: 'de', value: 'Leitidee' }],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/l3',
+              label: [{ lang: 'de', value: 'Raum und Form' }],
+              annotation: [{ lang: 'de', value: '1.3' }]
+            }],
+            valueAsText: [{ lang: 'de', value: '1.3 Raum und Form' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues);
+
+      expect(result.profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        label: [{ lang: 'de', value: '1.3 Raum und Form' }],
+        annotation: []
+      }]);
+    });
+
+    it('folds the annotation into an imported text entry and drops the annotation key', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 'w2',
+            label: [],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/l3',
+              text: [{ lang: 'de', value: 'Raum und Form' }],
+              annotation: [{ lang: 'de', value: '1.3' }]
+            }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues);
+
+      expect(result.profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        text: [{ lang: 'de', value: '1.3 Raum und Form' }]
+      }]);
+    });
+
+    it('leaves a vocabulary entry without numbering unchanged (label kept, annotation empty)', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 'w3',
+            label: [],
+            value: [{
+              id: 'https://w3id.org/iqb/v24/kh/r5f',
+              label: [{ lang: 'de', value: 'nein' }],
+              annotation: []
+            }],
+            valueAsText: [{ lang: 'de', value: 'nein' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues);
+
+      expect(result.profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/v24/kh/r5f',
+        label: [{ lang: 'de', value: 'nein' }],
+        annotation: []
+      }]);
+    });
+
+    it('passes simple (non-vocabulary) values through untouched', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 's1',
+            label: [],
+            value: { raw: 'true', asText: [{ lang: 'de', value: 'ja' }] },
+            valueAsText: [{ lang: 'de', value: 'ja' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      expect(UnitDownloadClass.toLegacyMetadataBlob(metadata)).toEqual(metadata);
+    });
+
+    it('keeps the pure label (no numbering) when the field hides numbering', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 'w1',
+            label: [],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/l3',
+              label: [{ lang: 'de', value: 'Raum und Form' }],
+              annotation: [{ lang: 'de', value: '1.3' }]
+            }],
+            valueAsText: [{ lang: 'de', value: 'Raum und Form' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues, { p1: { w1: true } });
+
+      expect(result.profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        label: [{ lang: 'de', value: 'Raum und Form' }],
+        annotation: []
+      }]);
+    });
+
+    it('keeps the pure text (imported, no numbering) when the field hides numbering', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [{
+          profileId: 'p1',
+          order: 0,
+          entries: [{
+            id: 'w2',
+            label: [],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/l3',
+              text: [{ lang: 'de', value: 'Raum und Form' }],
+              annotation: [{ lang: 'de', value: '1.3' }]
+            }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues, { p1: { w2: true } });
+
+      expect(result.profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        text: [{ lang: 'de', value: 'Raum und Form' }]
+      }]);
+    });
+
+    it('folds annotations inside item metadata as well', () => {
+      const result = UnitDownloadClass.toLegacyMetadataBlob({
+        profiles: [],
+        items: [{
+          id: 'item-1',
+          profiles: [{
+            profileId: 'p1',
+            order: 0,
+            entries: [{
+              id: 'w4',
+              label: [],
+              value: [{
+                id: 'https://w3id.org/iqb/vocab/l3',
+                label: [{ lang: 'de', value: 'Raum und Form' }],
+                annotation: [{ lang: 'de', value: '1.3' }]
+              }],
+              valueAsText: [{ lang: 'de', value: '1.3 Raum und Form' }]
+            }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues);
+
+      expect(result.items[0].profiles[0].entries[0].value).toEqual([{
+        id: 'https://w3id.org/iqb/vocab/l3',
+        label: [{ lang: 'de', value: '1.3 Raum und Form' }],
+        annotation: []
+      }]);
     });
   });
 

--- a/apps/api/src/app/classes/unit-download.class.ts
+++ b/apps/api/src/app/classes/unit-download.class.ts
@@ -36,6 +36,7 @@ import {
   UnitMetadataJson
 } from '../interfaces/unit-json-specs.interface';
 import { VeronaModulesService } from '../services/verona-modules.service';
+import { combineNotationAndLabel } from './metadata-value.util';
 import { SettingService } from '../services/setting.service';
 import { UnitCommentService } from '../services/unit-comment.service';
 import { UnitRichNoteService } from '../services/unit-rich-note.service';
@@ -180,7 +181,8 @@ export class UnitDownloadClass {
       unitExportConfig,
       unitMetadata
     );
-    UnitDownloadClass.addMetadata(unitMetadata, zip);
+    const hideNumbering = await unitService.buildHideNumberingMap(unitMetadata.metadata);
+    UnitDownloadClass.addMetadata(unitMetadata, zip, hideNumbering);
     const definitionData = await unitService.findOnesDefinition(unitId);
     UnitDownloadClass.addUnitDefinition(
       definitionData,
@@ -240,14 +242,88 @@ export class UnitDownloadClass {
 
   static addMetadata(
     unitMetadata: UnitPropertiesDto,
-    zip: AdmZip
+    zip: AdmZip,
+    hideNumbering: Record<string, Record<string, boolean>> = {}
   ): void {
     if (Object.keys(unitMetadata.metadata).length !== 0) {
       zip.addFile(
         `${unitMetadata.key}.vomd`,
-        Buffer.from(JSON.stringify(unitMetadata.metadata))
+        Buffer.from(JSON.stringify(UnitDownloadClass.toLegacyMetadataBlob(unitMetadata.metadata, hideNumbering)))
       );
     }
+  }
+
+  // The legacy XML export writes the internal metadata blob (`${key}.vomd`) as-is.
+  // metadata-values@3.x split the vocabulary numbering off the label into a
+  // separate `annotation` field — a JSON-export concern. To keep the .vomd blob
+  // exactly as legacy consumers expect, fold the split back before serializing:
+  // when the field shows numbering, merge it into the display text; when it hides
+  // numbering (hideNumbering), keep the pure label — matching the shape the old
+  // form baked at save time. Only vocabulary values are touched.
+  static toLegacyMetadataBlob(
+    metadata: UnitMetadataValues,
+    hideNumbering: Record<string, Record<string, boolean>> = {}
+  ): UnitMetadataValues {
+    if (!metadata || typeof metadata !== 'object') return metadata;
+    const foldProfile = <T extends ProfileValues>(profile: T): T => UnitDownloadClass.foldProfileAnnotations(
+      profile,
+      hideNumbering[profile.profileId ?? ''] ?? {}
+    );
+    return {
+      ...metadata,
+      ...(metadata.profiles && { profiles: metadata.profiles.map(foldProfile) }),
+      ...(metadata.items && {
+        items: metadata.items.map(item => ({
+          ...item,
+          ...(item.profiles && { profiles: item.profiles.map(foldProfile) })
+        }))
+      })
+    };
+  }
+
+  private static foldProfileAnnotations<T extends ProfileValues>(
+    profile: T,
+    hideNumberingByEntry: Record<string, boolean>
+  ): T {
+    if (!profile?.entries) return profile;
+    return {
+      ...profile,
+      entries: profile.entries.map(
+        entry => UnitDownloadClass.foldEntryAnnotation(entry, hideNumberingByEntry[entry.id] ?? false)
+      )
+    };
+  }
+
+  private static foldEntryAnnotation(entry: MetadataValuesEntry, hideNumbering: boolean): MetadataValuesEntry {
+    const { value } = entry;
+    if (!Array.isArray(value) || !value.some(item => !!item && typeof item === 'object' && 'id' in item)) {
+      return entry;
+    }
+    return {
+      ...entry,
+      value: value.map(item => UnitDownloadClass.foldVocabValueToLegacy(item, hideNumbering)) as
+        MetadataValuesEntry['value']
+    };
+  }
+
+  // Restores the pre-split shape: form-created entries kept the text in `label`
+  // (with an empty `annotation`), imported entries in `text` (without
+  // `annotation`). The numbering is merged back only when it is shown; with
+  // hideNumbering the pure label is kept, exactly as the old form stored it.
+  private static foldVocabValueToLegacy(item: unknown, hideNumbering: boolean): unknown {
+    if (!item || typeof item !== 'object' || !('id' in item)) return item;
+    const entry = item as {
+      id: string; label?: LanguageCodedText[]; text?: LanguageCodedText[]; annotation?: LanguageCodedText[];
+    };
+    if (entry.label !== undefined) {
+      const label = hideNumbering ? entry.label : combineNotationAndLabel(entry.annotation, entry.label);
+      return { id: entry.id, label, annotation: [] };
+    }
+    if (entry.text !== undefined) {
+      const text = hideNumbering ? entry.text : combineNotationAndLabel(entry.annotation, entry.text);
+      return { id: entry.id, text };
+    }
+    return item;
   }
 
   static addUnitDefinition(
@@ -605,14 +681,19 @@ export class UnitDownloadClass {
       const vocabularyEntries = value
         .filter(entryValue => !!entryValue && typeof (entryValue as { id?: unknown }).id === 'string')
         .map(entryValue => {
-          const vocabularyEntry = entryValue as { id: string; label?: unknown; text?: unknown };
-          // metadata-values@3.x carries the vocab text in `label`, the legacy form in `text`.
+          const vocabularyEntry = entryValue as {
+            id: string; label?: unknown; text?: unknown; annotation?: unknown;
+          };
+          // metadata-values@3.x carries the vocab text in `label`, the legacy form in
+          // `text`; the numbering (SKOS notation) travels in `annotation`.
           const texts = vocabularyEntry.label ?? vocabularyEntry.text;
           UnitDownloadClass.reportDroppedTexts(texts, entry.id, scope);
           const label = UnitDownloadClass.toLanguageCodedTexts(texts);
+          const annotation = UnitDownloadClass.toLanguageCodedTexts(vocabularyEntry.annotation);
           return {
             id: vocabularyEntry.id,
-            ...(label && { label })
+            ...(label && { label }),
+            ...(annotation && { annotation })
           };
         });
       if (vocabularyEntries.length) {

--- a/apps/api/src/app/services/metadata-profile.service.spec.ts
+++ b/apps/api/src/app/services/metadata-profile.service.spec.ts
@@ -50,6 +50,25 @@ describe('MetadataProfileService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('getStoredMetadataProfileFromDb', () => {
+    it('returns the stored profile from the DB without a background network fetch', async () => {
+      const profile = new MetadataProfile();
+      metadataProfileRepository.findOneBy.mockResolvedValue(profile);
+
+      const result = await service.getStoredMetadataProfileFromDb('url');
+
+      expect(result).toBe(profile);
+      expect(metadataProfileRepository.findOneBy).toHaveBeenCalledWith({ id: 'url' });
+      expect(httpService.get).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the profile is not stored', async () => {
+      metadataProfileRepository.findOneBy.mockResolvedValue(null);
+      await expect(service.getStoredMetadataProfileFromDb('missing')).resolves.toBeNull();
+      expect(httpService.get).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getStoredMetadataProfile', () => {
     it('should return stored profile if found', async () => {
       const profile = new MetadataProfile();

--- a/apps/api/src/app/services/metadata-profile.service.ts
+++ b/apps/api/src/app/services/metadata-profile.service.ts
@@ -29,6 +29,14 @@ export class MetadataProfileService {
     return this.getMetadataProfile(url);
   }
 
+  // DB-only read (no background network refresh). For hot read paths that only
+  // need the stored profile definition — e.g. resolving hideNumbering per entry
+  // when building the display text — so a units list does not spam the profile
+  // host with one fetch per unit.
+  getStoredMetadataProfileFromDb(url: string): Promise<MetadataProfile | null> {
+    return this.metadataProfileRepository.findOneBy({ id: url });
+  }
+
   private async getMetadataProfile(url: string): Promise<MetadataProfileDto | null> {
     const profile = await firstValueFrom(
       this.http.get<MetadataProfileDto>(url)

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -22,6 +22,7 @@ import UnitDropBoxHistory from '../entities/unit-drop-box-history.entity';
 import { UnitMetadataService } from './unit-metadata.service';
 import { UnitItemService } from './unit-item.service';
 import { UnitMetadataToDeleteService } from './unit-metadata-to-delete.service';
+import { MetadataProfileService } from './metadata-profile.service';
 import { UnitNotFoundException } from '../exceptions/unit-not-found.exception';
 
 describe('UnitService', () => {
@@ -36,6 +37,7 @@ describe('UnitService', () => {
   let unitMetadataService: DeepMocked<UnitMetadataService>;
   let unitItemService: DeepMocked<UnitItemService>;
   let unitMetadataToDeleteService: DeepMocked<UnitMetadataToDeleteService>;
+  let metadataProfileService: DeepMocked<MetadataProfileService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -60,6 +62,10 @@ describe('UnitService', () => {
         {
           provide: UnitMetadataToDeleteService,
           useValue: createMock<UnitMetadataToDeleteService>()
+        },
+        {
+          provide: MetadataProfileService,
+          useValue: createMock<MetadataProfileService>()
         },
         {
           provide: getRepositoryToken(Unit),
@@ -99,6 +105,7 @@ describe('UnitService', () => {
     unitMetadataService = module.get(UnitMetadataService);
     unitItemService = module.get(UnitItemService);
     unitMetadataToDeleteService = module.get(UnitMetadataToDeleteService);
+    metadataProfileService = module.get(MetadataProfileService);
   });
 
   it('should be defined', () => {
@@ -504,6 +511,72 @@ describe('UnitService', () => {
       expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
     });
 
+    it('combines the annotation (numbering) into valueAsText by default', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [{ lang: 'de', value: 'Prozess' }],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/p2',
+              label: [{ lang: 'de', value: 'Anwenden' }],
+              annotation: [{ lang: 'de', value: '1.2' }]
+            }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata);
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: '1.2 Anwenden' }]);
+    });
+
+    it('drops the numbering when the entry hideNumbering flag is set', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [{ lang: 'de', value: 'Prozess' }],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/p2',
+              label: [{ lang: 'de', value: 'Anwenden' }],
+              annotation: [{ lang: 'de', value: '1.2' }]
+            }],
+            valueAsText: []
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata, { p1: { e1: true } });
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
+    });
+
+    it('recomputes vocabulary valueAsText even when one was already stored (hideNumbering applies to imports)', () => {
+      const metadata = {
+        profiles: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'e1',
+            label: [{ lang: 'de', value: 'Prozess' }],
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/p2',
+              text: [{ lang: 'de', value: 'Anwenden' }],
+              annotation: [{ lang: 'de', value: '1.2' }]
+            }],
+            valueAsText: [{ lang: 'de', value: '1.2 Anwenden' }]
+          }]
+        }]
+      } as unknown as UnitMetadataValues;
+
+      const result = UnitService.ensureValueAsText(metadata, { p1: { e1: true } });
+
+      expect(result.profiles[0].entries[0].valueAsText).toEqual([{ lang: 'de', value: 'Anwenden' }]);
+    });
+
     it('derives valueAsText from form-created vocabulary entries that carry label', () => {
       const metadata = {
         profiles: [{
@@ -588,14 +661,16 @@ describe('UnitService', () => {
       expect(result.profiles[0].entries[0].valueAsText).toEqual([]);
     });
 
-    it('does not overwrite an existing valueAsText', () => {
+    it('does not overwrite an existing valueAsText for non-vocabulary values', () => {
+      // Vocabulary display text is always recomputed (so hideNumbering applies),
+      // but other value types keep a stored valueAsText.
       const metadata = {
         profiles: [{
           profileId: 'p1',
           entries: [{
             id: 'e1',
             label: [],
-            value: [{ id: 'v', text: [{ lang: 'de', value: 'Neu' }] }],
+            value: [{ lang: 'de', value: 'Neu' }],
             valueAsText: [{ lang: 'de', value: 'Alt' }]
           }]
         }]
@@ -721,6 +796,43 @@ describe('UnitService', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('connection lost'));
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('buildHideNumberingMap', () => {
+    it('extracts hideNumbering per entry from the stored profile definition', async () => {
+      metadataProfileService.getStoredMetadataProfileFromDb.mockResolvedValue({
+        id: 'p1',
+        groups: [{
+          entries: [
+            { id: 'e1', parameters: { hideNumbering: true } },
+            { id: 'e2', parameters: { hideNumbering: false } },
+            { id: 'e3', parameters: null }
+          ]
+        }]
+      } as never);
+
+      const metadata = {
+        profiles: [{ profileId: 'p1', entries: [] }],
+        items: [{ id: 'i1', profiles: [{ profileId: 'p1', entries: [] }] }]
+      } as unknown as UnitMetadataValues;
+
+      const map = await service.buildHideNumberingMap(metadata);
+
+      // only the flagged entry is recorded; false/null yield no entry
+      expect(map).toEqual({ p1: { e1: true } });
+      // the profile is looked up once even though two profiles reference it
+      expect(metadataProfileService.getStoredMetadataProfileFromDb).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty map when the profile is not stored', async () => {
+      metadataProfileService.getStoredMetadataProfileFromDb.mockResolvedValue(null);
+      const metadata = { profiles: [{ profileId: 'p1', entries: [] }] } as unknown as UnitMetadataValues;
+      await expect(service.buildHideNumberingMap(metadata)).resolves.toEqual({});
+    });
+
+    it('returns an empty map for undefined metadata', async () => {
+      await expect(service.buildHideNumberingMap(undefined)).resolves.toEqual({});
     });
   });
 });

--- a/apps/api/src/app/services/unit.service.spec.ts
+++ b/apps/api/src/app/services/unit.service.spec.ts
@@ -834,5 +834,19 @@ describe('UnitService', () => {
     it('returns an empty map for undefined metadata', async () => {
       await expect(service.buildHideNumberingMap(undefined)).resolves.toEqual({});
     });
+
+    it('reuses a shared profile cache across units so the profile is fetched once', async () => {
+      metadataProfileService.getStoredMetadataProfileFromDb.mockResolvedValue({
+        id: 'p1',
+        groups: [{ entries: [{ id: 'e1', parameters: { hideNumbering: true } }] }]
+      } as never);
+      const cache = new Map();
+      const metadata = { profiles: [{ profileId: 'p1', entries: [] }] } as unknown as UnitMetadataValues;
+
+      await service.buildHideNumberingMap(metadata, cache);
+      await service.buildHideNumberingMap(metadata, cache);
+
+      expect(metadataProfileService.getStoredMetadataProfileFromDb).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -20,9 +20,11 @@ import {
   UnitSchemeDto
 } from '@studio-lite-lib/api-dto';
 import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { LanguageCodedText } from '@iqbspecs/metadata-profile';
 import {
   orderFromCurrent, profileIdsMatch, reconcileProfilesByProfileId
 } from '@studio-lite/shared-code';
+import { combineNotationAndLabel } from '../classes/metadata-value.util';
 import Workspace from '../entities/workspace.entity';
 import Unit from '../entities/unit.entity';
 import UnitDefinition from '../entities/unit-definition.entity';
@@ -33,6 +35,7 @@ import User from '../entities/user.entity';
 import UnitDropBoxHistory from '../entities/unit-drop-box-history.entity';
 import { UnitMetadataService } from './unit-metadata.service';
 import { UnitItemService } from './unit-item.service';
+import { MetadataProfileService } from './metadata-profile.service';
 import { UnitMetadataToDeleteService } from './unit-metadata-to-delete.service';
 import { UnitNotFoundException } from '../exceptions/unit-not-found.exception';
 import { ItemUuidLookup } from '../interfaces/item-uuid-lookup.interface';
@@ -57,7 +60,8 @@ export class UnitService {
     private unitCommentService: UnitCommentService,
     private unitMetadataService: UnitMetadataService,
     private unitItemService: UnitItemService,
-    private unitMetadataToDeleteService: UnitMetadataToDeleteService
+    private unitMetadataToDeleteService: UnitMetadataToDeleteService,
+    private metadataProfileService: MetadataProfileService
   ) {}
 
   async findOne(id: number): Promise<Unit> {
@@ -398,7 +402,7 @@ export class UnitService {
       // findOnesMetadata already backfills valueAsText.
       unit.metadata = await this.findOnesMetadata(unit.id);
     } else {
-      unit.metadata = UnitService.ensureValueAsText(
+      unit.metadata = await this.resolveValueAsText(
         UnitService.setCurrentProfiles(
           workspace.settings?.unitMDProfile,
           workspace.settings?.itemMDProfile,
@@ -454,32 +458,62 @@ export class UnitService {
   // already language-coded. A plain string cannot be resolved here (a coded value
   // needs its vocabulary, free text carries no language), so it is left empty
   // rather than guessed. Returns new objects; the stored entities are not mutated.
-  static ensureValueAsText(metadata: UnitMetadataValues): UnitMetadataValues {
+  // hideNumbering maps profileId -> entryId -> true when that vocabulary field
+  // hides the numbering. Empty (the default) keeps the numbering everywhere,
+  // which matches the behaviour before hideNumbering was honoured server-side.
+  static ensureValueAsText(
+    metadata: UnitMetadataValues,
+    hideNumbering: Record<string, Record<string, boolean>> = {}
+  ): UnitMetadataValues {
     if (!metadata) return metadata;
+    const forProfile = <T extends ProfileValues>(profile: T): T => UnitService.fillProfileValueAsText(
+      profile,
+      hideNumbering[profile.profileId ?? ''] ?? {}
+    );
     return {
       ...metadata,
-      ...(metadata.profiles && { profiles: metadata.profiles.map(UnitService.fillProfileValueAsText) }),
+      ...(metadata.profiles && { profiles: metadata.profiles.map(forProfile) }),
       ...(metadata.items && {
         items: metadata.items.map(item => ({
           ...item,
-          ...(item.profiles && { profiles: item.profiles.map(UnitService.fillProfileValueAsText) })
+          ...(item.profiles && { profiles: item.profiles.map(forProfile) })
         }))
       })
     };
   }
 
-  private static fillProfileValueAsText<T extends ProfileValues>(profile: T): T {
+  private static fillProfileValueAsText<T extends ProfileValues>(
+    profile: T,
+    hideNumberingByEntry: Record<string, boolean>
+  ): T {
     if (!profile.entries) return profile;
-    return { ...profile, entries: profile.entries.map(UnitService.fillEntryValueAsText) };
+    return {
+      ...profile,
+      entries: profile.entries.map(
+        entry => UnitService.fillEntryValueAsText(entry, hideNumberingByEntry[entry.id] ?? false)
+      )
+    };
   }
 
-  private static fillEntryValueAsText(entry: MetadataValuesEntry): MetadataValuesEntry {
+  private static fillEntryValueAsText(entry: MetadataValuesEntry, hideNumbering: boolean): MetadataValuesEntry {
+    const { value } = entry;
+    const isVocabulary = Array.isArray(value) &&
+      value.some(item => !!item && typeof item === 'object' && 'id' in item);
+    // Vocabulary display text is always recomputed so hideNumbering applies even
+    // when a valueAsText was already stored (e.g. imported units); other value
+    // types keep their stored valueAsText and are only backfilled when empty.
+    if (isVocabulary) {
+      return { ...entry, valueAsText: UnitService.getEntryValueAsText(value, hideNumbering) };
+    }
     const hasText = Array.isArray(entry.valueAsText) ? entry.valueAsText.length > 0 : !!entry.valueAsText;
     if (hasText) return entry;
-    return { ...entry, valueAsText: UnitService.getEntryValueAsText(entry.value) };
+    return { ...entry, valueAsText: UnitService.getEntryValueAsText(value) };
   }
 
-  private static getEntryValueAsText(value: MetadataValuesEntry['value']): MetadataValuesEntry['valueAsText'] {
+  private static getEntryValueAsText(
+    value: MetadataValuesEntry['value'],
+    hideNumbering = false
+  ): MetadataValuesEntry['valueAsText'] {
     // metadata-values@3.x simple value { raw, asText } (form-created; the legacy
     // form stored a plain string instead and has no asText to recover).
     if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -487,16 +521,57 @@ export class UnitService {
     }
     if (!Array.isArray(value)) return [];
     if (value.some(item => item && typeof item === 'object' && 'id' in item)) {
-      // vocabulary entries: metadata-values@3.x carries the display text in `label`,
-      // the legacy internal form in `text`.
+      // vocabulary entries: metadata-values@3.x carries the pure label in `label`
+      // (legacy internal form in `text`) and the numbering in `annotation`; the
+      // display text combines numbering + label.
       return value.flatMap(item => {
         if (!item || typeof item !== 'object' || !('id' in item)) return [];
-        const vocab = item as { label?: unknown[]; text?: unknown[] };
-        return vocab.label ?? vocab.text ?? [];
+        const vocab = item as {
+          label?: LanguageCodedText[]; text?: LanguageCodedText[]; annotation?: LanguageCodedText[];
+        };
+        const texts = vocab.label ?? vocab.text;
+        return hideNumbering ? (texts ?? []) : combineNotationAndLabel(vocab.annotation, texts);
       }) as MetadataValuesEntry['valueAsText'];
     }
     // no vocabulary entries -> already multilingual free text
     return value as MetadataValuesEntry['valueAsText'];
+  }
+
+  // Applies valueAsText (incl. hideNumbering) for display. The hideNumbering
+  // flags come from the stored profile definitions, so vocabulary numbering is
+  // suppressed consistently in every read-only view that consumes valueAsText.
+  private async resolveValueAsText(metadata: UnitMetadataValues): Promise<UnitMetadataValues> {
+    const hideNumbering = await this.buildHideNumberingMap(metadata);
+    return UnitService.ensureValueAsText(metadata, hideNumbering);
+  }
+
+  // Builds profileId -> entryId -> hideNumbering from the DB-stored profile
+  // definitions of every profile referenced by the metadata (unit and item
+  // profiles). DB-only reads keep this cheap on list endpoints. Public so the
+  // XML export can fold the numbering back the same way (see toLegacyMetadataBlob).
+  async buildHideNumberingMap(
+    metadata: UnitMetadataValues | undefined
+  ): Promise<Record<string, Record<string, boolean>>> {
+    if (!metadata) return {};
+    const profileIds = new Set<string>();
+    (metadata.profiles ?? []).forEach(profile => {
+      if (profile.profileId) profileIds.add(profile.profileId);
+    });
+    (metadata.items ?? []).forEach(item => (item.profiles ?? []).forEach(profile => {
+      if (profile.profileId) profileIds.add(profile.profileId);
+    }));
+    const map: Record<string, Record<string, boolean>> = {};
+    await Promise.all([...profileIds].map(async profileId => {
+      const profile = await this.metadataProfileService.getStoredMetadataProfileFromDb(profileId);
+      if (!profile?.groups) return;
+      const entryMap: Record<string, boolean> = {};
+      profile.groups.forEach(group => (group.entries ?? []).forEach(entry => {
+        const parameters = entry.parameters as unknown as { hideNumbering?: boolean } | null;
+        if (parameters?.hideNumbering) entryMap[entry.id] = true;
+      }));
+      map[profileId] = entryMap;
+    }));
+    return map;
   }
 
   // Reconcile unit metadata by profileId (the profile form re-emits without the
@@ -909,7 +984,7 @@ export class UnitService {
       // the index signature of ItemsMetadataValues blocks direct assignment
       return await this.findOnesMetadata(createFrom) as unknown as UnitMetadataValues;
     }
-    return UnitService.ensureValueAsText(unit.metadata as UnitMetadataValues);
+    return this.resolveValueAsText(unit.metadata as UnitMetadataValues);
   }
 
   async findOnesMetadata(unitId: number): Promise<UnitFullMetadataDto> {
@@ -918,6 +993,6 @@ export class UnitService {
       items: await this.unitItemService
         .getAllByUnitIdWithMetadata(unitId) as unknown as UnitMetadataValues['items']
     };
-    return UnitService.ensureValueAsText(metadata) as unknown as UnitFullMetadataDto;
+    return await this.resolveValueAsText(metadata) as unknown as UnitFullMetadataDto;
   }
 }

--- a/apps/api/src/app/services/unit.service.ts
+++ b/apps/api/src/app/services/unit.service.ts
@@ -40,6 +40,11 @@ import { UnitMetadataToDeleteService } from './unit-metadata-to-delete.service';
 import { UnitNotFoundException } from '../exceptions/unit-not-found.exception';
 import { ItemUuidLookup } from '../interfaces/item-uuid-lookup.interface';
 
+// Dedupes profile lookups within a single request (a units list shares the same
+// profiles across units). Caches the pending promise so parallel unit reads
+// under Promise.all reuse one DB fetch instead of each firing its own.
+type ProfileFetchCache = Map<string, ReturnType<MetadataProfileService['getStoredMetadataProfileFromDb']>>;
+
 export class UnitService {
   private readonly logger = new Logger(UnitService.name);
 
@@ -393,10 +398,15 @@ export class UnitService {
         'lastChangedMetadataUser', 'lastChangedDefinitionUser', 'lastChangedSchemeUser'
       ]
     });
-    return Promise.all(units.map(async unit => this.getModifiedMetadataForUnit(unit, workspace)));
+    const profileCache: ProfileFetchCache = new Map();
+    return Promise.all(units.map(async unit => this.getModifiedMetadataForUnit(unit, workspace, profileCache)));
   }
 
-  private async getModifiedMetadataForUnit(unit: Unit, workspace: Workspace): Promise<Unit> {
+  private async getModifiedMetadataForUnit(
+    unit: Unit,
+    workspace: Workspace,
+    profileCache?: ProfileFetchCache
+  ): Promise<Unit> {
     const unitMetadataToDelete = await this.unitMetadataToDeleteService.getOneByUnit(unit.id);
     if (unitMetadataToDelete) {
       // findOnesMetadata already backfills valueAsText.
@@ -407,7 +417,8 @@ export class UnitService {
           workspace.settings?.unitMDProfile,
           workspace.settings?.itemMDProfile,
           unit.metadata
-        )
+        ),
+        profileCache
       );
     }
     return unit;
@@ -540,8 +551,11 @@ export class UnitService {
   // Applies valueAsText (incl. hideNumbering) for display. The hideNumbering
   // flags come from the stored profile definitions, so vocabulary numbering is
   // suppressed consistently in every read-only view that consumes valueAsText.
-  private async resolveValueAsText(metadata: UnitMetadataValues): Promise<UnitMetadataValues> {
-    const hideNumbering = await this.buildHideNumberingMap(metadata);
+  private async resolveValueAsText(
+    metadata: UnitMetadataValues,
+    profileCache?: ProfileFetchCache
+  ): Promise<UnitMetadataValues> {
+    const hideNumbering = await this.buildHideNumberingMap(metadata, profileCache);
     return UnitService.ensureValueAsText(metadata, hideNumbering);
   }
 
@@ -550,7 +564,8 @@ export class UnitService {
   // profiles). DB-only reads keep this cheap on list endpoints. Public so the
   // XML export can fold the numbering back the same way (see toLegacyMetadataBlob).
   async buildHideNumberingMap(
-    metadata: UnitMetadataValues | undefined
+    metadata: UnitMetadataValues | undefined,
+    profileCache: ProfileFetchCache = new Map()
   ): Promise<Record<string, Record<string, boolean>>> {
     if (!metadata) return {};
     const profileIds = new Set<string>();
@@ -562,11 +577,16 @@ export class UnitService {
     }));
     const map: Record<string, Record<string, boolean>> = {};
     await Promise.all([...profileIds].map(async profileId => {
-      const profile = await this.metadataProfileService.getStoredMetadataProfileFromDb(profileId);
+      let pending = profileCache.get(profileId);
+      if (!pending) {
+        pending = this.metadataProfileService.getStoredMetadataProfileFromDb(profileId);
+        profileCache.set(profileId, pending);
+      }
+      const profile = await pending;
       if (!profile?.groups) return;
       const entryMap: Record<string, boolean> = {};
       profile.groups.forEach(group => (group.entries ?? []).forEach(entry => {
-        const parameters = entry.parameters as unknown as { hideNumbering?: boolean } | null;
+        const parameters = entry.parameters as { hideNumbering?: boolean } | null;
         if (parameters?.hideNumbering) entryMap[entry.id] = true;
       }));
       map[profileId] = entryMap;

--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -489,11 +489,12 @@ describe('WorkspaceService', () => {
         value: [{
           id: 'https://w3id.org/iqb/vocab/p2', text: [{ lang: 'de', value: 'Anwenden' }], annotation: []
         }],
-        valueAsText: [{ lang: 'de', value: 'Anwenden' }]
+        // vocabulary valueAsText is recomputed on read, not at import time
+        valueAsText: []
       });
     });
 
-    it('preserves the annotation (numbering) and combines it into valueAsText', () => {
+    it('preserves the annotation (numbering) in the value; valueAsText is filled on read', () => {
       const mapped = WorkspaceService.mapImportedMetadata({
         metadata: [{
           profileId: 'p1',
@@ -516,7 +517,8 @@ describe('WorkspaceService', () => {
           text: [{ lang: 'de', value: 'Anwenden' }],
           annotation: [{ lang: 'de', value: '1.2' }]
         }],
-        valueAsText: [{ lang: 'de', value: '1.2 Anwenden' }]
+        // recomputed by UnitService.ensureValueAsText on read (see unit.service.spec)
+        valueAsText: []
       });
     });
 

--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -486,8 +486,37 @@ describe('WorkspaceService', () => {
       expect(mapped.profiles[0].entries[0]).toEqual({
         id: 'w4',
         label: [],
-        value: [{ id: 'https://w3id.org/iqb/vocab/p2', text: [{ lang: 'de', value: 'Anwenden' }] }],
+        value: [{
+          id: 'https://w3id.org/iqb/vocab/p2', text: [{ lang: 'de', value: 'Anwenden' }], annotation: []
+        }],
         valueAsText: [{ lang: 'de', value: 'Anwenden' }]
+      });
+    });
+
+    it('preserves the annotation (numbering) and combines it into valueAsText', () => {
+      const mapped = WorkspaceService.mapImportedMetadata({
+        metadata: [{
+          profileId: 'p1',
+          entries: [{
+            id: 'w5',
+            value: [{
+              id: 'https://w3id.org/iqb/vocab/p2',
+              label: [{ lang: 'de', value: 'Anwenden' }],
+              annotation: [{ lang: 'de', value: '1.2' }]
+            }]
+          }]
+        }]
+      });
+
+      expect(mapped.profiles[0].entries[0]).toEqual({
+        id: 'w5',
+        label: [],
+        value: [{
+          id: 'https://w3id.org/iqb/vocab/p2',
+          text: [{ lang: 'de', value: 'Anwenden' }],
+          annotation: [{ lang: 'de', value: '1.2' }]
+        }],
+        valueAsText: [{ lang: 'de', value: '1.2 Anwenden' }]
       });
     });
 
@@ -916,7 +945,7 @@ describe('WorkspaceService', () => {
       }]);
     });
 
-    it('should warn when imported vocabulary entries carry annotations the model cannot hold', async () => {
+    it('does not warn when imported vocabulary entries carry an annotation (it is now persisted)', async () => {
       (unitService.create as jest.Mock).mockResolvedValue(10);
       (unitService.patchUnitProperties as jest.Mock).mockResolvedValue([]);
       (unitService.copyItemsWithMetadata as jest.Mock).mockResolvedValue([]);
@@ -930,7 +959,7 @@ describe('WorkspaceService', () => {
             value: [{
               id: 'https://w3id.org/iqb/vocab/p2',
               label: [{ lang: 'de', value: 'Anwenden' }],
-              annotation: [{ lang: 'de', value: 'Hinweis' }]
+              annotation: [{ lang: 'de', value: '1.2' }]
             }]
           }]
         }]
@@ -942,10 +971,9 @@ describe('WorkspaceService', () => {
         buildFile('unit01.vomd.json', 'application/json', vomdContent)
       ], user);
 
-      expect(result.messages).toEqual([{
-        objectKey: 'unit01.vomd.json',
-        messageKey: 'unit-upload.api-warning.annotation-dropped'
-      }]);
+      expect(result.messages.some(
+        message => message.messageKey === 'unit-upload.api-warning.annotation-dropped'
+      )).toBe(false);
     });
 
     it('should warn when coding scheme file referenced in index is missing from upload', async () => {

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -38,6 +38,7 @@ import Unit from '../entities/unit.entity';
 import { FileIo } from '../interfaces/file-io.interface';
 import { UnitImportData } from '../classes/unit-import-data.class';
 import { UnitImportJsonData } from '../classes/unit-import-json-data.class';
+import { combineNotationAndLabel } from '../classes/metadata-value.util';
 import { UnitService } from './unit.service';
 import { AdminWorkspaceNotFoundException } from '../exceptions/admin-workspace-not-found.exception';
 import WorkspaceGroupAdmin from '../entities/workspace-group-admin.entity';
@@ -853,11 +854,6 @@ export class WorkspaceService {
           );
           if (parsedMetadata !== undefined) {
             unitImportData.metadata = WorkspaceService.mapImportedMetadata(parsedMetadata);
-            WorkspaceService.warnDroppedAnnotations(
-              (parsedMetadata as UnitMetadataJson)?.metadata,
-              unitImportData.metadataFileName,
-              functionReturn
-            );
           }
           usedFiles.push(unitImportData.metadataFileName);
         } else {
@@ -877,11 +873,6 @@ export class WorkspaceService {
               ...(unitImportData.metadata ?? {}),
               items: WorkspaceService.mapImportedItems(parsedItems)
             };
-            if (Array.isArray(parsedItems)) {
-              parsedItems.forEach(item => WorkspaceService.warnDroppedAnnotations(
-                item?.metadata, unitImportData.itemsFileName, functionReturn
-              ));
-            }
           }
           usedFiles.push(unitImportData.itemsFileName);
         } else {
@@ -944,32 +935,6 @@ export class WorkspaceService {
       objectKey: fileName,
       messageKey: 'unit-upload.api-warning.missing-file'
     });
-  }
-
-  // The internal model (TextWithLanguageAndId: { id, text }) has no field for
-  // the spec-optional `annotation` of vocabulary entries, so annotations from
-  // third-party files cannot be stored — surface the drop instead of losing
-  // the data silently. One warning per companion file.
-  private static warnDroppedAnnotations(
-    values: MetadataValuesJson[] | undefined,
-    fileName: string,
-    functionReturn: RequestReportDto
-  ): void {
-    if (!Array.isArray(values)) return;
-    const hasAnnotations = values.some(profile => (profile?.entries ?? []).some(
-      entry => Array.isArray(entry?.value) && (entry.value as VocabularyEntryJson[]).some(
-        vocabularyEntry => Array.isArray(vocabularyEntry?.annotation) && vocabularyEntry.annotation.length > 0
-      )
-    ));
-    if (hasAnnotations && !functionReturn.messages.some(
-      message => message.objectKey === fileName &&
-        message.messageKey === 'unit-upload.api-warning.annotation-dropped'
-    )) {
-      functionReturn.messages.push({
-        objectKey: fileName,
-        messageKey: 'unit-upload.api-warning.annotation-dropped'
-      });
-    }
   }
 
   // Parses a companion JSON file (vocs/voco/vorn/vomd/voit/vova). A broken
@@ -1180,11 +1145,19 @@ export class WorkspaceService {
     if (Array.isArray(value)) {
       if (value.some(entryValue => !!entryValue && typeof (entryValue as VocabularyEntryJson).id === 'string')) {
         const vocabularyEntries = value as VocabularyEntryJson[];
+        // Preserve the spec field `annotation` (the numbering / SKOS notation);
+        // the pure label stays in `text`. Display text combines both.
         internalValue = vocabularyEntries.map(vocabularyEntry => ({
           id: vocabularyEntry.id,
-          text: vocabularyEntry.label ?? []
+          text: vocabularyEntry.label ?? [],
+          annotation: vocabularyEntry.annotation ?? []
         }));
-        valueAsText = vocabularyEntries.flatMap(vocabularyEntry => vocabularyEntry.label ?? []);
+        valueAsText = vocabularyEntries.flatMap(
+          vocabularyEntry => combineNotationAndLabel(
+            vocabularyEntry.annotation,
+            vocabularyEntry.label
+          )
+        );
       } else {
         internalValue = value as LanguageCodedText[];
         valueAsText = value as LanguageCodedText[];

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -38,7 +38,6 @@ import Unit from '../entities/unit.entity';
 import { FileIo } from '../interfaces/file-io.interface';
 import { UnitImportData } from '../classes/unit-import-data.class';
 import { UnitImportJsonData } from '../classes/unit-import-json-data.class';
-import { combineNotationAndLabel } from '../classes/metadata-value.util';
 import { UnitService } from './unit.service';
 import { AdminWorkspaceNotFoundException } from '../exceptions/admin-workspace-not-found.exception';
 import WorkspaceGroupAdmin from '../entities/workspace-group-admin.entity';
@@ -1146,18 +1145,16 @@ export class WorkspaceService {
       if (value.some(entryValue => !!entryValue && typeof (entryValue as VocabularyEntryJson).id === 'string')) {
         const vocabularyEntries = value as VocabularyEntryJson[];
         // Preserve the spec field `annotation` (the numbering / SKOS notation);
-        // the pure label stays in `text`. Display text combines both.
+        // the pure label stays in `text`. valueAsText is left empty here because
+        // the read path (UnitService.ensureValueAsText) always recomputes the
+        // vocabulary display text, honouring hideNumbering — computing it now
+        // would only be overwritten.
         internalValue = vocabularyEntries.map(vocabularyEntry => ({
           id: vocabularyEntry.id,
           text: vocabularyEntry.label ?? [],
           annotation: vocabularyEntry.annotation ?? []
         }));
-        valueAsText = vocabularyEntries.flatMap(
-          vocabularyEntry => combineNotationAndLabel(
-            vocabularyEntry.annotation,
-            vocabularyEntry.label
-          )
-        );
+        valueAsText = [];
       } else {
         internalValue = value as LanguageCodedText[];
         valueAsText = value as LanguageCodedText[];

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -32,8 +32,7 @@
       "xml-parse": "Nicht als Unit-Xml erkannt",
       "json-parse": "Nicht als Unit-Json-Index erkannt",
       "missing-file": "Referenzierte Datei nicht im Upload gefunden",
-      "ignore-file": "Datei wurde ignoriert",
-      "annotation-dropped": "Anmerkungen (annotation) zu Vokabular-Einträgen können nicht gespeichert werden und wurden verworfen"
+      "ignore-file": "Datei wurde ignoriert"
     },
     "menu-label": {
       "import": "Import",

--- a/libs/api-dto/src/lib/dtos/metadata-profile/metadata-profile.dto.ts
+++ b/libs/api-dto/src/lib/dtos/metadata-profile/metadata-profile.dto.ts
@@ -25,5 +25,8 @@ export class MetadataProfileGroupEntry {
   id!: string;
   label!: TextWithLanguage[];
   type!: string;
-  parameters!: Record<string, unknown>[];
+  // A single parameter object (e.g. ProfileEntryParametersVocabulary) or null —
+  // matching the metadata-profile spec, where `parameters` is one keyed object,
+  // not an array.
+  parameters!: Record<string, unknown> | null;
 }

--- a/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
+++ b/libs/api-dto/src/lib/dtos/unit/profile-metadata-values.class.ts
@@ -1,5 +1,4 @@
 // eslint-disable-next-line max-classes-per-file
-import { TextWithLanguageAndId as TextsWithLanguageAndId } from '@iqb/metadata-resolver';
 import { LanguageCodedText as TextWithLanguage } from '@iqbspecs/metadata-profile';
 
 export class ProfileMetadataValues {
@@ -32,9 +31,20 @@ export class ItemsMetadataValues extends ProfileMetadataValues {
   [key: string]: string | number | ProfileValues[] | null | undefined | boolean | Date;
 }
 
+// Internal vocabulary value entry. The display text lives in `label`
+// (form-created) or `text` (imported/legacy), the numbering in `annotation` —
+// the spec field `annotation` holds what the vocabulary exposes as its SKOS
+// notation.
+export interface VocabularyValueEntry {
+  id: string;
+  label?: TextWithLanguage[];
+  text?: TextWithLanguage[];
+  annotation?: TextWithLanguage[];
+}
+
 export class MetadataValuesEntry {
   id!: string;
   label!: TextWithLanguage[];
-  value!: TextsWithLanguageAndId[] | TextWithLanguage[] | string;
+  value!: VocabularyValueEntry[] | TextWithLanguage[] | string;
   valueAsText!: TextWithLanguage | TextWithLanguage[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-browser-dynamic": "20.3.25",
         "@angular/router": "20.3.25",
         "@golevelup/ts-jest": "^0.3.4",
-        "@iqb/metadata-components": "0.2.8",
+        "@iqb/metadata-components": "^0.2.9",
         "@iqb/metadata-resolver": "0.2.1",
         "@iqb/ngx-coding-components": "3.1.2",
         "@iqb/responses": "5.2.0",
@@ -4963,9 +4963,9 @@
       }
     },
     "node_modules/@iqb/metadata-components": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@iqb/metadata-components/-/metadata-components-0.2.8.tgz",
-      "integrity": "sha512-N36KWQ8TXajiFK4iHbWUKcM36WhaHkGYTLgEnCtJg93/tYVOF+ibf9Tx/2fLM4l8EIslBHUUD6rzzzzS7DFE0g==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@iqb/metadata-components/-/metadata-components-0.2.9.tgz",
+      "integrity": "sha512-Up2yuPWZNMW7xgAEJywyIUC5vptCG7hSLhq+sWpMxKopTOe6pDo8xZatG1+nv+b12Z4qo3h8J1PbtBxtIb+XZA==",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser-dynamic": "20.3.25",
     "@angular/router": "20.3.25",
     "@golevelup/ts-jest": "^0.3.4",
-    "@iqb/metadata-components": "0.2.8",
+    "@iqb/metadata-components": "0.2.9",
     "@iqb/metadata-resolver": "0.2.1",
     "@iqb/ngx-coding-components": "3.1.2",
     "@iqb/responses": "5.2.0",


### PR DESCRIPTION
## Kontext

Schließt iqb-berlin/studio-lite#1535. Konsumiert `@iqb/metadata-components@0.2.9` (PR iqb-berlin/metadata-components#23), das das Vokabular-`label` rein hält und die Nummerierung im Spec-Feld `annotation` (SKOS-notation) trägt. studio-lite bewahrt dieses Feld jetzt überall, statt es zu verwerfen.

## Root Cause

Bisher wurde `annotation` an drei Stellen fallengelassen (Import → internes `text`, Export, Anzeige nur aus `label`) und aktiv verworfen (`warnDroppedAnnotations`) — bei spec-konformen Importen ging so die **Nummerierung** verloren.

## Änderungen

- **Import** (`mapMetadataEntryJson`): `annotation` ins interne Modell durchreichen; `warnDroppedAnnotations` + i18n-Key `annotation-dropped` entfernt.
- **Export** (`transformEntryValue`): `annotation` im JSON-Spec-Output mit ausgeben; Items nutzen denselben Transform.
- **Anzeige** (`ensureValueAsText`): Nummerierung + Label zu `valueAsText` kombinieren, **`hideNumbering`** des Profilfelds beachtend. Die Flags kommen aus den **DB-gecachten** Profildefinitionen (neuer DB-only-Getter `getStoredMetadataProfileFromDb`), server-seitig angewandt — so bleibt jede Read-only-Ansicht (Report, Print, Review) konsistent. Vokabular-`valueAsText` wird **immer** neu berechnet, damit `hideNumbering` auch bei importierten Units mit gespeichertem `valueAsText` greift.
- **XML-Export** (`.vomd`): Split zurück in die eingefrorene Legacy-Form falten — Nummer ins Anzeige-Feld gemergt, wenn sie gezeigt wird, reines Label behalten bei `hideNumbering` — der Legacy-Blob bleibt **exakt wie vorher**.
- **api-dto**: `VocabularyValueEntry` bekommt optionales `annotation` (`{ id, label?, text?, annotation? }`).

## Warum server-seitig (nicht Frontend)

Ein zuerst gebauter Frontend-Weg wurde verworfen: Print und Review laden kein Vokabular-Dictionary → dort hätte `hideNumbering` nicht gegriffen (inkonsistent je View). Die `MetadataProfile`-Entity cachet die volle Definition (`groups` jsonb) lokal → server-seitig ist es günstig und deckt **alle** Read-only-Kontexte einheitlich ab.

## Tests

- API **731** grün (neu: Util `combineNotationAndLabel`, Import-Preserve, Export-`annotation`, `ensureValueAsText`+hideNumbering, `toLegacyMetadataBlob`-Fold inkl. hideNumbering, `buildHideNumberingMap`-Extraktion/Dedup).
- Frontend **1939** grün, Lint + Builds grün.
- Lokal wurde B (Paket 0.2.9) und C gemeinsam end-to-end verifiziert.

## Hinweis

Die hideNumbering-Map wird pro Unit aus DB-PK-Reads gebaut; bei sehr großen Unit-Listen ließe sich das später auf Listen-Ebene deduplizieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
