### PR TITLE
feat: Aufgabenexport – JSON als experimentell kennzeichnen, Reihenfolge tauschen

### DIFF
--- a/apps/frontend/src/app/modules/workspace/components/export-unit-file-config/export-unit-file-config.component.html
+++ b/apps/frontend/src/app/modules/workspace/components/export-unit-file-config/export-unit-file-config.component.html
@@ -2,8 +2,8 @@
   <div class="header">{{'unit-download.export-format' | translate}}</div>
   <mat-radio-group [ngModel]="exportFormat"
                    (ngModelChange)="exportFormatChange.emit($event)">
-    <mat-radio-button value="json">{{'unit-download.export-format-json' | translate}}</mat-radio-button>
     <mat-radio-button value="xml">{{'unit-download.export-format-xml' | translate}}</mat-radio-button>
+    <mat-radio-button value="json">{{'unit-download.export-format-json' | translate}}</mat-radio-button>
   </mat-radio-group>
   <div class="header">{{'unit-download.add-files' | translate}}</div>
   <mat-checkbox [ngModel]="addComments"

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -42,8 +42,8 @@
   },
   "unit-download": {
     "export-format": "Exportformat",
-    "export-format-json": "JSON",
-    "export-format-xml": "XML (Standard)",
+    "export-format-json": "JSON (Experimentell)",
+    "export-format-xml": "XML",
     "add-files": "Zusätzliche Dateien",
     "add-player": "Player hinzufügen",
     "add-comments": "Kommentare hinzufügen",


### PR DESCRIPTION
## Was

Im Dialog zum Aufgabenexport (Bereich **Exportformat**) werden die beiden Optionen angepasst:

- **Reihenfolge vertauscht**: XML steht jetzt oben, JSON darunter.
- **JSON** erhält den Zusatz **„(Experimentell)"**.
- **XML** verliert den nicht mehr benötigten Zusatz „(Standard)".

Neu:

- XML
- JSON (Experimentell)

## Änderungen

- `export-unit-file-config.component.html`: Reihenfolge der `mat-radio-button`-Optionen getauscht.
- `de.json`: `export-format-json` → `"JSON (Experimentell)"`, `export-format-xml` → `"XML"`.

## Tests

Weder Unit- noch E2E-Tests sind betroffen:

- Unit-Spec nutzt `TranslateModule.forRoot()` ohne Übersetzungen und prüft weder Reihenfolge noch die deutschen Labels; der Default (`exportFormat === 'json'`, Component-Logik) bleibt unverändert.
- Der E2E-Export-Test klickt den Export-Button mit Default-Format und wählt keine Radio-Option per Position oder Text aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)