### PR TITLE
feat: accept both upper- and lower-case Verona module types

### DIFF
--- a/apps/api/src/app/classes/unit-download.class.ts
+++ b/apps/api/src/app/classes/unit-download.class.ts
@@ -806,7 +806,7 @@ export class UnitDownloadClass {
     usedPlayers: string[]
   ): Promise<void> {
     const allPlayers: VeronaModuleInListDto[] =
-      await veronaModuleService.findAll('player');
+      await veronaModuleService.findAll('PLAYER');
     const veronaKeyList = new VeronaModuleKeyCollection(
       allPlayers.map(p => p.key)
     );

--- a/apps/api/src/app/controllers/admin-verona-module.controller.spec.ts
+++ b/apps/api/src/app/controllers/admin-verona-module.controller.spec.ts
@@ -52,6 +52,26 @@ describe('AdminVeronaModuleController', () => {
         .toHaveBeenCalledWith(mockFile.buffer, ['WIDGET']);
     });
 
+    it('should accept the current upper-case module types', async () => {
+      const mockFile = { buffer: Buffer.from('test') };
+      veronaModulesService.upload.mockResolvedValue(undefined);
+
+      await controller.addModuleFile(mockFile, ['EDITOR', 'PLAYER', 'SCHEMER']);
+
+      expect(veronaModulesService.upload)
+        .toHaveBeenCalledWith(mockFile.buffer, ['EDITOR', 'PLAYER', 'SCHEMER']);
+    });
+
+    it('should still accept the legacy lower-case module types', async () => {
+      const mockFile = { buffer: Buffer.from('test') };
+      veronaModulesService.upload.mockResolvedValue(undefined);
+
+      await controller.addModuleFile(mockFile, ['editor', 'player', 'schemer']);
+
+      expect(veronaModulesService.upload)
+        .toHaveBeenCalledWith(mockFile.buffer, ['editor', 'player', 'schemer']);
+    });
+
     it('should reject unknown types', async () => {
       const mockFile = { buffer: Buffer.from('test') };
 

--- a/apps/api/src/app/controllers/admin-verona-module.controller.ts
+++ b/apps/api/src/app/controllers/admin-verona-module.controller.ts
@@ -13,6 +13,7 @@ import {
   ApiBearerAuth, ApiCreatedResponse, ApiNotAcceptableResponse, ApiOkResponse, ApiQuery, ApiTags, ApiUnauthorizedResponse
 } from '@nestjs/swagger';
 import { VeronaModuleInListDto, VeronaModuleType } from '@studio-lite-lib/api-dto';
+import { VERONA_MODULE_TYPES, isKnownVeronaModuleType } from '@studio-lite/shared-code';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { VeronaModulesService } from '../services/verona-modules.service';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
@@ -37,23 +38,23 @@ export class AdminVeronaModuleController {
   @ApiQuery({
     name: 'type',
     type: String,
-    description: 'required, array of module types: editor, player, schemer, widget',
+    // Both the current upper-case spelling and the legacy lower-case spelling are accepted.
+    description: 'required, array of module types: EDITOR, PLAYER, SCHEMER, WIDGET',
     required: true,
     isArray: true,
-    enum: ['editor', 'player', 'schemer', 'WIDGET']
+    enum: VERONA_MODULE_TYPES
   })
   async addModuleFile(
   @UploadedFile() file,
     @Query('type', new ParseArrayPipe({ items: String, separator: ',' })) types: string[]
   ) {
-    const allowedTypes = ['editor', 'player', 'schemer', 'WIDGET'] as const;
     const normalizedTypes = types.map(type => type.trim()).filter(Boolean);
 
     if (!normalizedTypes.length) {
       throw new NotAcceptableException('Module type is required.');
     }
 
-    const invalidTypes = normalizedTypes.filter(type => !allowedTypes.includes(type as VeronaModuleType));
+    const invalidTypes = normalizedTypes.filter(type => !isKnownVeronaModuleType(type));
     if (invalidTypes.length) {
       throw new NotAcceptableException(`Unknown module type(s): ${invalidTypes.join(', ')}`);
     }

--- a/apps/api/src/app/controllers/verona-module.controller.ts
+++ b/apps/api/src/app/controllers/verona-module.controller.ts
@@ -25,7 +25,7 @@ export class VeronaModuleController {
   @ApiQuery({
     name: 'type',
     type: String,
-    description: 'specify the type of module if needed: schemer, editor, player, widget',
+    description: 'specify the type of module if needed: EDITOR, PLAYER, SCHEMER, WIDGET (case-insensitive)',
     required: false
   })
   @ApiOkResponse({ description: 'Verona modules retrieved successfully.' })

--- a/apps/api/src/app/services/verona-modules.service.spec.ts
+++ b/apps/api/src/app/services/verona-modules.service.spec.ts
@@ -96,6 +96,59 @@ describe('VeronaModulesService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('e');
     });
+
+    it('should match the query type case-insensitively (upper-case query, legacy metadata)', async () => {
+      const modules = [
+        { key: 'e', metadata: { type: 'editor', name: 'e' } },
+        { key: 'p', metadata: { type: 'player', name: 'p' } }
+      ];
+      mockRepository.find.mockResolvedValue(modules);
+
+      const result = await service.findAll('EDITOR');
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('e');
+    });
+
+    it('should match the query type case-insensitively (legacy query, upper-case metadata)', async () => {
+      const modules = [
+        { key: 'e', metadata: { type: 'EDITOR', name: 'e' } },
+        { key: 'p', metadata: { type: 'PLAYER', name: 'p' } }
+      ];
+      mockRepository.find.mockResolvedValue(modules);
+
+      const result = await service.findAll('editor');
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('e');
+    });
+  });
+
+  describe('upload', () => {
+    const buildModuleBuffer = (type: string): Buffer => {
+      const jsonLd = JSON.stringify({
+        type,
+        model: 'm',
+        id: 'mod',
+        version: '1.0.0',
+        specVersion: '5.0',
+        name: [{ lang: 'de', value: 'Name' }]
+      });
+      return Buffer.from(
+        `<html><head><script type="application/ld+json">${jsonLd}</script></head></html>`
+      );
+    };
+
+    it('accepts an upper-case metadata type against a legacy lower-case allowedTypes filter', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockImplementation(m => m);
+
+      await expect(service.upload(buildModuleBuffer('EDITOR'), ['editor'])).resolves.toBeUndefined();
+      expect(repository.save).toHaveBeenCalled();
+    });
+
+    it('rejects a metadata type that is not in allowedTypes', async () => {
+      await expect(service.upload(buildModuleBuffer('EDITOR'), ['player'])).rejects.toThrow();
+      expect(repository.save).not.toHaveBeenCalled();
+    });
   });
 
   describe('remove', () => {

--- a/apps/api/src/app/services/verona-modules.service.ts
+++ b/apps/api/src/app/services/verona-modules.service.ts
@@ -7,7 +7,7 @@ import {
   VeronaModuleFileDto, VeronaModuleInListDto, VeronaModuleMetadataDto, VeronaModuleType
 } from '@studio-lite-lib/api-dto';
 import * as cheerio from 'cheerio';
-import { VeronaModuleKeyCollection } from '@studio-lite/shared-code';
+import { VeronaModuleKeyCollection, veronaModuleTypesMatch } from '@studio-lite/shared-code';
 import type { Response } from 'express';
 import VeronaModule from '../entities/verona-module.entity';
 import { AdminVeronaModulesNotFoundException } from '../exceptions/admin-verona-modules-not-found.exception';
@@ -60,7 +60,7 @@ export class VeronaModulesService {
       select: ['key', 'metadata', 'fileSize', 'fileDateTime']
     })) ?? [];
     return veronaModules
-      .filter(vm => !type || vm.metadata?.type === type)
+      .filter(vm => !type || veronaModuleTypesMatch(vm.metadata?.type, type))
       .map(vm => <VeronaModuleInListDto>{
         key: vm.key,
         sortKey: VeronaModuleKeyCollection.getSortKey(vm.key),
@@ -83,7 +83,8 @@ export class VeronaModulesService {
       const scriptContentAsJson = JSON.parse(scriptContentAsString);
       const veronaModuleMetadata = VeronaModuleMetadataDto.getFromJsonLd(scriptContentAsJson);
       if (veronaModuleMetadata) {
-        if (allowedTypes && !allowedTypes.includes(veronaModuleMetadata.type)) {
+        if (allowedTypes &&
+          !allowedTypes.some(t => veronaModuleTypesMatch(t, veronaModuleMetadata.type))) {
           throw new NotAcceptableException('verona module type not accepted');
         }
         const moduleKey = VeronaModuleMetadataDto.getKey(veronaModuleMetadata);

--- a/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.html
+++ b/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.html
@@ -34,21 +34,21 @@
       </iqb-files-upload-queue>
       <div class="fx-column-start-stretch">
         <h2>{{'modules.player-name' | translate}}</h2>
-        <studio-lite-verona-modules-table type="player"
+        <studio-lite-verona-modules-table type="PLAYER"
                                           [modules]="moduleService.players"
                                           (selectionChanged)="changeSelectedModules($event)">
         </studio-lite-verona-modules-table>
       </div>
       <div class="fx-column-start-stretch">
         <h2>{{'modules.editor-name' | translate}}</h2>
-        <studio-lite-verona-modules-table type="editor"
+        <studio-lite-verona-modules-table type="EDITOR"
                                           [modules]="moduleService.editors"
                                           (selectionChanged)="changeSelectedModules($event)">
         </studio-lite-verona-modules-table>
       </div>
       <div class="fx-column-start-stretch">
         <h2>{{'modules.schemer-name' | translate}}</h2>
-        <studio-lite-verona-modules-table type="schemer"
+        <studio-lite-verona-modules-table type="SCHEMER"
                                           [modules]="moduleService.schemers"
                                           (selectionChanged)="changeSelectedModules($event)">
         </studio-lite-verona-modules-table>

--- a/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.spec.ts
+++ b/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.spec.ts
@@ -165,6 +165,21 @@ describe('VeronaModulesComponent', () => {
     expect(component.selectedModules).not.toContain(module1);
   });
 
+  it('should replace selection case-insensitively when metadata uses the legacy lower-case type', () => {
+    const legacyEditor = { metadata: { type: 'editor' }, key: 'm1' } as VeronaModuleClass;
+    const player = { metadata: { type: 'PLAYER' }, key: 'm2' } as VeronaModuleClass;
+    const newEditor = { metadata: { type: 'EDITOR' }, key: 'm3' } as VeronaModuleClass;
+
+    component.selectedModules = [legacyEditor, player];
+
+    component.changeSelectedModules({ type: 'EDITOR', selectedModules: [newEditor] });
+
+    expect(component.selectedModules).toHaveLength(2);
+    expect(component.selectedModules).toContain(player);
+    expect(component.selectedModules).toContain(newEditor);
+    expect(component.selectedModules).not.toContain(legacyEditor);
+  });
+
   it('should delete modules successfully', () => {
     component.selectedModules = [{ key: 'm1' }] as VeronaModuleClass[];
 

--- a/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.ts
+++ b/apps/frontend/src/app/modules/admin/components/verona-modules/verona-modules.component.ts
@@ -9,6 +9,7 @@ import { MatButton } from '@angular/material/button';
 import {
   IqbFilesUploadInputForDirective, IqbFilesUploadQueueComponent
 } from '@studio-lite-lib/iqb-components';
+import { veronaModuleTypesMatch } from '@studio-lite/shared-code';
 import { ModuleService } from '../../../../services/module.service';
 import { BackendService } from '../../services/backend.service';
 import { AppService } from '../../../../services/app.service';
@@ -27,7 +28,7 @@ import { ModuleSelectionChange } from '../../models/module-selection-change.inte
 })
 export class VeronaModulesComponent extends ModulesDirective {
   protected readonly pageTitleKey = 'modules.title';
-  protected readonly uploadPath = 'admin/verona-modules?type=editor&type=player&type=schemer';
+  protected readonly uploadPath = 'admin/verona-modules?type=EDITOR&type=PLAYER&type=SCHEMER';
 
   protected serverUrl: string;
   protected appService: AppService;
@@ -66,7 +67,7 @@ export class VeronaModulesComponent extends ModulesDirective {
     const newSelection: VeronaModuleClass[] = [];
 
     this.selectedModules.forEach(module => {
-      if (module.metadata?.type !== selection.type) {
+      if (!veronaModuleTypesMatch(module.metadata?.type, selection.type)) {
         newSelection.push(module);
       }
     });

--- a/apps/frontend/src/app/services/module.service.spec.ts
+++ b/apps/frontend/src/app/services/module.service.spec.ts
@@ -31,39 +31,39 @@ describe('ModuleService', () => {
   describe('loadList', () => {
     it('should populate editors, players, and schemers dictionaries', async () => {
       const mockModulesByType: Record<string, VeronaModuleInListDto[]> = {
-        editor: [{
+        EDITOR: [{
           key: 'e1',
           sortKey: 'e1',
           metadata: {
             id: 'e1',
             name: 'E1',
-            type: 'editor',
+            type: 'EDITOR',
             model: '',
             version: '1.0',
             specVersion: '1.0',
             isStable: true
           }
         }],
-        player: [{
+        PLAYER: [{
           key: 'p1',
           sortKey: 'p1',
           metadata: {
             id: 'p1',
             name: 'P1',
-            type: 'player',
+            type: 'PLAYER',
             model: 'speedTest',
             version: '1.0',
             specVersion: '1.0',
             isStable: true
           }
         }],
-        schemer: [{
+        SCHEMER: [{
           key: 's1',
           sortKey: 's1',
           metadata: {
             id: 's1',
             name: 'S1',
-            type: 'schemer',
+            type: 'SCHEMER',
             model: 'iqb',
             version: '1.0',
             specVersion: '1.0',
@@ -76,9 +76,9 @@ describe('ModuleService', () => {
 
       await service.loadList();
 
-      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('editor');
-      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('player');
-      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('schemer');
+      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('EDITOR');
+      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('PLAYER');
+      expect(mockBackendService.getModuleList).toHaveBeenCalledWith('SCHEMER');
 
       expect(Object.keys(service.editors)).toHaveLength(1);
       // eslint-disable-next-line @typescript-eslint/dot-notation

--- a/apps/frontend/src/app/services/module.service.ts
+++ b/apps/frontend/src/app/services/module.service.ts
@@ -20,9 +20,9 @@ export class ModuleService {
 
   async loadList() {
     const [editorModules, playerModules, schemerModules] = await Promise.all([
-      lastValueFrom(this.backendService.getModuleList('editor')),
-      lastValueFrom(this.backendService.getModuleList('player')),
-      lastValueFrom(this.backendService.getModuleList('schemer'))
+      lastValueFrom(this.backendService.getModuleList('EDITOR')),
+      lastValueFrom(this.backendService.getModuleList('PLAYER')),
+      lastValueFrom(this.backendService.getModuleList('SCHEMER'))
     ]);
 
     this.editors = ModuleService.toModuleMap(editorModules);

--- a/libs/api-dto/src/lib/dtos/verona-module/verona-module-metadata.dto.ts
+++ b/libs/api-dto/src/lib/dtos/verona-module/verona-module-metadata.dto.ts
@@ -1,6 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export type VeronaModuleType = 'editor' | 'player' | 'schemer' | 'WIDGET';
+// The Verona module metadata specification moved to upper-case type identifiers (EDITOR, PLAYER,
+// SCHEMER, WIDGET). Older modules still ship the historical lower-case spelling, so both casings
+// stay valid internally and are compared case-insensitively via veronaModuleTypesMatch (shared-code).
+export type VeronaModuleType =
+  | 'EDITOR' | 'PLAYER' | 'SCHEMER' | 'WIDGET'
+  | 'editor' | 'player' | 'schemer' | 'widget';
 
 export class VeronaModuleMetadataDto {
   [index: string]: unknown;

--- a/libs/shared-code/src/index.ts
+++ b/libs/shared-code/src/index.ts
@@ -2,6 +2,12 @@ export { VeronaModuleFactory } from './lib/helper/verona-module.factory';
 export { VeronaModuleKeyCollection } from './lib/helper/verona-module-key-collection.class';
 export { canonicalizeProfileId, profileIdsMatch, isItemProfileId } from './lib/profile-id';
 export {
+  VERONA_MODULE_TYPES,
+  normalizeVeronaModuleType,
+  veronaModuleTypesMatch,
+  isKnownVeronaModuleType
+} from './lib/verona-module-type';
+export {
   HIDDEN_PROFILE_ORDER, ACTIVE_PROFILE_ORDER, orderFromCurrent, isCurrentFromOrder
 } from './lib/profile-order';
 export {

--- a/libs/shared-code/src/lib/verona-module-type.spec.ts
+++ b/libs/shared-code/src/lib/verona-module-type.spec.ts
@@ -1,0 +1,61 @@
+import {
+  VERONA_MODULE_TYPES,
+  normalizeVeronaModuleType,
+  veronaModuleTypesMatch,
+  isKnownVeronaModuleType
+} from './verona-module-type';
+
+describe('verona-module-type', () => {
+  describe('VERONA_MODULE_TYPES', () => {
+    it('lists the four canonical upper-case module types', () => {
+      expect(VERONA_MODULE_TYPES).toEqual(['EDITOR', 'PLAYER', 'SCHEMER', 'WIDGET']);
+    });
+  });
+
+  describe('normalizeVeronaModuleType', () => {
+    it('upper-cases and trims the given type', () => {
+      expect(normalizeVeronaModuleType(' editor ')).toBe('EDITOR');
+    });
+
+    it('leaves an already canonical type unchanged', () => {
+      expect(normalizeVeronaModuleType('WIDGET')).toBe('WIDGET');
+    });
+
+    it('returns an empty string for nullish input', () => {
+      expect(normalizeVeronaModuleType(undefined)).toBe('');
+      expect(normalizeVeronaModuleType(null)).toBe('');
+    });
+  });
+
+  describe('veronaModuleTypesMatch', () => {
+    it('matches the legacy lower-case spelling against the current upper-case spelling', () => {
+      expect(veronaModuleTypesMatch('editor', 'EDITOR')).toBe(true);
+      expect(veronaModuleTypesMatch('PLAYER', 'player')).toBe(true);
+    });
+
+    it('matches identical spellings', () => {
+      expect(veronaModuleTypesMatch('SCHEMER', 'SCHEMER')).toBe(true);
+    });
+
+    it('does not match different types', () => {
+      expect(veronaModuleTypesMatch('editor', 'player')).toBe(false);
+    });
+
+    it('does not match when one side is empty', () => {
+      expect(veronaModuleTypesMatch('', 'EDITOR')).toBe(false);
+      expect(veronaModuleTypesMatch(undefined, null)).toBe(true);
+    });
+  });
+
+  describe('isKnownVeronaModuleType', () => {
+    it('accepts both spellings of a known type', () => {
+      expect(isKnownVeronaModuleType('editor')).toBe(true);
+      expect(isKnownVeronaModuleType('WIDGET')).toBe(true);
+    });
+
+    it('rejects unknown types', () => {
+      expect(isKnownVeronaModuleType('unknown')).toBe(false);
+      expect(isKnownVeronaModuleType('')).toBe(false);
+    });
+  });
+});

--- a/libs/shared-code/src/lib/verona-module-type.ts
+++ b/libs/shared-code/src/lib/verona-module-type.ts
@@ -1,0 +1,33 @@
+/**
+ * Verona module type identifiers.
+ *
+ * The Verona module metadata specification moved to upper-case type identifiers
+ * (EDITOR, PLAYER, SCHEMER, WIDGET). Modules published before that change still
+ * ship the historical lower-case spelling (editor, player, schemer). Both spellings
+ * must therefore stay valid throughout studio-lite: newly emitted type strings use
+ * the canonical upper-case form, while every comparison against a module's stored
+ * `metadata.type` is done case-insensitively via veronaModuleTypesMatch.
+ *
+ * These helpers are kept in shared-code (rather than on the swagger-decorated
+ * VeronaModuleMetadataDto) so the frontend can call them without bundling
+ * `@nestjs/swagger`.
+ */
+
+// Canonical (upper-case) module types as defined by the current Verona module metadata spec.
+export const VERONA_MODULE_TYPES = ['EDITOR', 'PLAYER', 'SCHEMER', 'WIDGET'] as const;
+
+// Reduces a module type to its canonical (upper-case, trimmed) form so that the historical
+// lower-case spelling and the current upper-case spec spelling can be compared interchangeably.
+export function normalizeVeronaModuleType(type?: string | null): string {
+  return (type ?? '').trim().toUpperCase();
+}
+
+// Case-insensitive comparison of two module types (e.g. 'editor' matches 'EDITOR').
+export function veronaModuleTypesMatch(a?: string | null, b?: string | null): boolean {
+  return normalizeVeronaModuleType(a) === normalizeVeronaModuleType(b);
+}
+
+// Whether the given type is one of the four known Verona module types (in any casing).
+export function isKnownVeronaModuleType(type?: string | null): boolean {
+  return VERONA_MODULE_TYPES.some(known => veronaModuleTypesMatch(known, type));
+}


### PR DESCRIPTION
## Kontext

Die neue [Verona-Module-Metadata-Spec](https://raw.githubusercontent.com/verona-interfaces/verona-module-metadata/master/verona-module-metadata.schema.json) verwendet groß geschriebene Typ-Identifier: `EDITOR`, `PLAYER`, `SCHEMER`, `WIDGET`. `WIDGET` (kürzlich hinzugefügt) folgt der neuen Schreibweise bereits; `editor`/`player`/`schemer` mussten nachgezogen werden. Da ältere Module weiterhin die historische Kleinschreibung liefern, **müssen intern beide Schreibweisen gültig bleiben**.

## Änderungen

- **Zentrale, case-insensitive Vergleichslogik** in `@studio-lite/shared-code`: `normalizeVeronaModuleType`, `veronaModuleTypesMatch`, `isKnownVeronaModuleType`, `VERONA_MODULE_TYPES`. Bewusst **nicht** als Static am swagger-dekorierten `VeronaModuleMetadataDto`, damit das Frontend-Bundle nicht `@nestjs/swagger` (→ `swagger-ui-dist`) einzieht.
- **Case-insensitive Matching** an den drei realen Vergleichsstellen des Verona-`type`-Felds:
  - `VeronaModulesService.findAll` (Typ-Filter)
  - `VeronaModulesService.upload` (Allow-List-Prüfung)
  - Admin-Dedup in `VeronaModulesComponent`
- **studio-lite sendet nun die kanonische Großschreibung** (Modul-Listen-Requests, Upload-URLs, Admin-Tabellen-Inputs, Player-Lookup beim Download, Swagger-`enum`/Beschreibungen), **akzeptiert aber weiterhin die Kleinschreibung**.
- `VeronaModuleType`-Union auf beide Schreibweisen erweitert (nur Typebene, wird beim Build ge-erased).
- Unit-Tests für die Helper und alle geänderten Vergleichsstellen ergänzt/angepasst.

## Bewusst nicht angefasst

Routen-Pfade, DB-Spalten, `@ViewChild`-Namen, interne Map-Keys (`players`/`editors`/`schemers`), Unit-Metadaten-Keys, der Player-postMessage-Typ (`preview.directive.ts`) und die Widget-Model-Dedup — das sind eigene Bezeichner, nicht das Spec-`type`-Feld. Der lowercase e2e-Upload-Helper (`commands-api.ts`) bleibt bewusst als Backward-Compat-Regressions-Guard.

## Verifikation

- Builds: `api` ✓, `frontend` ✓ (kein Swagger im Bundle)
- Lint: `api`, `frontend`, `shared-code`, `api-dto` ✓
- Tests: 740 api-Tests ✓, shared-code-Helper (10) ✓, geänderte Frontend-Specs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)