### PR TITLE
fix: improve metadata report table dialog layout

### DIFF
--- a/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.html
+++ b/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.html
@@ -1,7 +1,10 @@
 
 
     <mat-dialog-content class="container">
-      <mat-tab-group animationDuration="0ms" #tabGroup (selectedTabChange)="tabChanged($event)">
+      <mat-tab-group class="metadata-tabs"
+                     animationDuration="0ms"
+                     #tabGroup
+                     (selectedTabChange)="tabChanged($event)">
         <mat-tab label="{{ 'metadata.units' | translate }}">
           <div mat-dialog-title class="fx-column-start-start title">
             <mat-form-field class="filter">
@@ -9,18 +12,22 @@
               <input matInput (keyup)="applyFilter($event)" #input>
             </mat-form-field>
           </div>
-          <table mat-table [dataSource]="dataSource" matSort>
-            @for (column of columnsToDisplay; track column) {
-              <ng-container [matColumnDef]="column">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                  {{ (displayedColumns | include: column) ? ('metadata.' + column | translate) : column }}
-                </th>
-                <td mat-cell [innerHTML]="element[column]" *matCellDef="let element"></td>
-              </ng-container>
-            }
-            <tr mat-header-row *matHeaderRowDef="columnsToDisplay;sticky:true"></tr>
-            <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"></tr>
-          </table>
+          <div class="table-container">
+            <table mat-table [dataSource]="dataSource" matSort>
+              @for (column of columnsToDisplay; track column) {
+                <ng-container [matColumnDef]="column">
+                  <th mat-header-cell *matHeaderCellDef mat-sort-header>
+                    {{ (displayedColumns | include: column) ? ('metadata.' + column | translate) : column }}
+                  </th>
+                  <td mat-cell *matCellDef="let element">
+                    <div class="cell-content" [innerHTML]="element[column]"></div>
+                  </td>
+                </ng-container>
+              }
+              <tr mat-header-row *matHeaderRowDef="columnsToDisplay;sticky:true"></tr>
+              <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"></tr>
+            </table>
+          </div>
         </mat-tab>
         <mat-tab label="{{ 'metadata.items' | translate }}">
           <div mat-dialog-title class="fx-column-start-start title">
@@ -29,18 +36,22 @@
               <input matInput (keyup)="applyFilter($event)" #input>
             </mat-form-field>
           </div>
-          <table mat-table [dataSource]="dataSource" matSort>
-            @for (column of columnsToDisplay; track column) {
-              <ng-container [matColumnDef]="column">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                  {{ (displayedColumns | include: column) ? ('metadata.' + column | translate) : column }}
-                </th>
-                <td mat-cell [innerHTML]="element[column]" *matCellDef="let element"></td>
-              </ng-container>
-            }
-            <tr mat-header-row *matHeaderRowDef="columnsToDisplay;sticky:true"></tr>
-            <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"></tr>
-          </table>
+          <div class="table-container">
+            <table mat-table [dataSource]="dataSource" matSort>
+              @for (column of columnsToDisplay; track column) {
+                <ng-container [matColumnDef]="column">
+                  <th mat-header-cell *matHeaderCellDef mat-sort-header>
+                    {{ (displayedColumns | include: column) ? ('metadata.' + column | translate) : column }}
+                  </th>
+                  <td mat-cell *matCellDef="let element">
+                    <div class="cell-content" [innerHTML]="element[column]"></div>
+                  </td>
+                </ng-container>
+              }
+              <tr mat-header-row *matHeaderRowDef="columnsToDisplay;sticky:true"></tr>
+              <tr mat-row *matRowDef="let row; columns: columnsToDisplay;"></tr>
+            </table>
+          </div>
         </mat-tab>
       </mat-tab-group>
     </mat-dialog-content>

--- a/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.scss
+++ b/apps/frontend/src/app/modules/metadata/components/table-view/table-view.component.scss
@@ -1,15 +1,63 @@
-mat-dialog-content{
-  padding:0!important;
+// Dialog is opened with a fixed height (80%). The flex chain below propagates
+// that height down through Material's tab structure so the table fills the
+// remaining space and stays the same height regardless of the number of rows.
+// min-width: 0 on every flex item lets them shrink below their content width,
+// so a wide table only produces ONE horizontal scrollbar (on .table-container)
+// instead of also forcing the tab containers to overflow.
+.container {
+  padding: 0 !important;
+  max-height: none; // override Material's default 65vh cap so the content fills the dialog
+  min-height: 0;
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.metadata-tabs {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+::ng-deep .mat-mdc-tab-body-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+::ng-deep .mat-mdc-tab-body-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.table-container {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  padding: 0 20px;
+  box-sizing: border-box;
 }
 
 table {
-  width: 80%;
-  overflow: scroll;
-  padding: 0 20px;
+  width: 100%;
 }
 
 td{
   padding: 10px !important;
+}
+
+.cell-content {
+  max-height: 120px;
+  overflow-y: auto;
 }
 
 .filter{
@@ -20,4 +68,3 @@ td{
 .mat-mdc-cell {
   vertical-align: top;
 }
-

--- a/apps/frontend/src/app/modules/workspace/components/edit-unit-button/edit-unit-button.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/edit-unit-button/edit-unit-button.component.ts
@@ -366,6 +366,7 @@ export class EditUnitButtonComponent extends RequestMessageDirective implements 
                   .filter((unit: UnitPropertiesDto) => res.selectedUnits.includes(unit.id));
                 this.showMetadataDialog.open(TableViewComponent, {
                   width: '80%',
+                  height: '80%',
                   data: {
                     units: selectedUnits,
                     warning: ''


### PR DESCRIPTION
## Kontext

Die Tabellenansicht im Metadaten-Bericht-Dialog (Einstellungen → Bericht → Metadaten) hatte bei langem Zellinhalt Darstellungsprobleme: sehr große Zeilenabstände und kein horizontaler Scrollbalken.

## Änderungen

- **Feste Dialoghöhe** (`edit-unit-button`): der Dialog wird mit `height: '80%'` geöffnet; die Tabelle füllt den Restplatz über eine Flexbox-Kette durch die Material-Tab-Struktur → beide Tabs (Aufgaben/Items) haben eine konstante Höhe, unabhängig von der Zeilenzahl.
- **Horizontaler Scrollbalken**: die Tabelle liegt jetzt in einem `.table-container` mit `overflow: auto` (statt `overflow: scroll` direkt auf dem `<table>`-Element, was nie als Scroll-Container wirkte).
- **Konstante Zeilenhöhe**: der Zellinhalt (`innerHTML`) liegt in einem `.cell-content` mit `max-height` + `overflow-y: auto` → langer Text bläht die Zeile nicht mehr auf, sondern scrollt pro Zelle.
- **Nur ein horizontaler Scrollbalken**: `min-width: 0` über die gesamte Flex-Kette, damit breiter Inhalt nicht zusätzlich die Tab-Container überlaufen lässt.

## Verifikation

- `nx lint frontend` ✔
- `nx test frontend` (table-view spec) ✔
- Reine Layout-/Präsentationsänderung, keine Logikänderung → keine Test-Anpassung nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)