### PR TITLE
Issue-Templates „Fehlermeldung“, „Neues Feature“ und „Anpassungsbedarf“ anlegen

### DIFF
--- a/.github/ISSUE_TEMPLATE/anpassungsbedarf.md
+++ b/.github/ISSUE_TEMPLATE/anpassungsbedarf.md
@@ -1,0 +1,20 @@
+---
+name: Anpassungsbedarf
+about: Anpassung oder Erweiterung eines bereits bestehenden Features
+title: ''
+labels: Anpassung
+assignees: ''
+
+---
+
+**Welches bestehende Feature soll angepasst werden?**
+Benennung des Features und wo es zu finden ist.
+
+**Ist-Zustand**
+Wie verhält sich das Feature aktuell?
+
+**Gewünschte Anpassung**
+Klare und kurze Beschreibung, was sich ändern soll und warum.
+
+**Weitere Informationen**
+Füge weitere Informationen, Screenshots, Skizzen oder Links zu Beispielaufgaben ein.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Neues Feature
+about: Vorschlag für neue Funktionen oder Erweiterungen
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Welches Problem oder welche Anforderung soll mit diesem Feature gelöst werden? Beschreibe.**
+Kurze und klare Beschreibung des Problems. Bspw. Ich bin frustriert wenn [...]
+
+**Beschreibe deinen Lösungsansatz**
+Was soll passieren oder sich ändern.
+
+**Beschreibe welche Alternativen du in Betracht gezogen hast**
+Welche Workarounds oder andere Lösungen gäbe es.
+
+**Weitere Informationen**
+Füge weitere Informationen, Skizzen oder Ähnliches ein.

--- a/.github/ISSUE_TEMPLATE/fehlermeldung.md
+++ b/.github/ISSUE_TEMPLATE/fehlermeldung.md
@@ -1,0 +1,30 @@
+---
+name: Fehlermeldung
+about: 'Etwas funktioniert nicht, wie erwartet.'
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Fehlerbeschreibung**
+Klare und kurze Beschreibung des Problems
+
+**Nachstellen**
+Schritte zum Nachstellen des Verhaltens:
+1. Gehe zu '...'
+2. Klicke auf '...'
+3. Fehlermeldung erscheint
+
+**Erwartetes Verhalten**
+Welches Verhalten wurde erwartet und was wurde stattdessen festgestellt.
+
+**Screenshots, Links, erschienene Fehlermeldungen**
+Bei Links auf Arbeitsbereiche oder Aufgaben im Studio bitte darauf achten, dass diese für uns sichtbar sind.
+
+**Versionen**
+- Verwendete Studio-Version
+- Betriebssystem: [z.B. iOS] (nur wichtig bei Mobilgeräten)
+- Browser [z.B. Chrome, Safari] mit Version
+
+**Weitere Information**


### PR DESCRIPTION
Legt Issue-Templates für das Studio an, analog zu den Templates in `verona-modules-aspect` (siehe iqb-berlin/verona-modules-aspect#1080, dort wurde ein drittes Template für Anpassungen an bestehenden Features gewünscht — „gern auch auf dem Studio-Board“):

- **Fehlermeldung** (`fehlermeldung.md`) — setzt automatisch das Label `bug`
- **Neues Feature** (`feature_request.md`) — setzt automatisch das Label `enhancement`
- **Anpassungsbedarf** (`anpassungsbedarf.md`) — setzt automatisch das neu angelegte Label `Anpassung`

Die Texte sind gegenüber den aspect-Vorlagen leicht ans Studio angepasst (keine Player-/Editor-Versionsabfrage, kein „erweiterter Modus“; stattdessen Studio-Version).

Da `develop` der Default-Branch ist, erscheinen die Templates direkt nach dem Merge im „New issue“-Dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)