### PR TITLE
fix: accept zip uploads from Windows for resource packages

### DIFF
--- a/apps/api/src/app/constants/zip-mime-types.spec.ts
+++ b/apps/api/src/app/constants/zip-mime-types.spec.ts
@@ -1,0 +1,15 @@
+import { ZIP_MIME_TYPES } from './zip-mime-types';
+
+describe('ZIP_MIME_TYPES', () => {
+  it('accepts the mime type sent by Linux and macOS', () => {
+    expect(ZIP_MIME_TYPES).toContain('application/zip');
+  });
+
+  it('accepts the mime type sent by Windows', () => {
+    expect(ZIP_MIME_TYPES).toContain('application/x-zip-compressed');
+  });
+
+  it('accepts the legacy multipart zip mime type', () => {
+    expect(ZIP_MIME_TYPES).toContain('multipart/x-zip');
+  });
+});

--- a/apps/api/src/app/constants/zip-mime-types.ts
+++ b/apps/api/src/app/constants/zip-mime-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Mime types browsers report for a `.zip` file.
+ *
+ * The value depends on the operating system: Linux and macOS send
+ * `application/zip`, while Windows derives it from the registry entry for the
+ * `.zip` extension and typically sends `application/x-zip-compressed`.
+ * All variants have to be accepted, otherwise zip uploads fail with HTTP 415
+ * depending on the client's platform.
+ */
+export const ZIP_MIME_TYPES = [
+  'application/zip',
+  'application/x-zip-compressed',
+  'multipart/x-zip'
+];

--- a/apps/api/src/app/controllers/admin-resource-package.controller.ts
+++ b/apps/api/src/app/controllers/admin-resource-package.controller.ts
@@ -18,6 +18,7 @@ import { IsAdminGuard } from '../guards/is-admin.guard';
 import { ApiFile } from '../decorators/api-file.decorator';
 import { fileMimetypeFilter } from '../filters/file-mimetype.filter';
 import { ParseFilePipe } from '../pipes/parse-file.pipe';
+import { ZIP_MIME_TYPES } from '../constants/zip-mime-types';
 
 @Controller('admin/resource-packages')
 export class AdminResourcePackageController {
@@ -47,7 +48,7 @@ export class AdminResourcePackageController {
   @UseGuards(JwtAuthGuard, IsAdminGuard)
   @ApiBearerAuth()
   @ApiFile('resourcePackage', true, {
-    fileFilter: fileMimetypeFilter('application/zip')
+    fileFilter: fileMimetypeFilter(...ZIP_MIME_TYPES)
   })
   @ApiCreatedResponse({
     description: 'Sends back the id of the new resource package in database',

--- a/apps/api/src/app/filters/file-mimetype.filter.spec.ts
+++ b/apps/api/src/app/filters/file-mimetype.filter.spec.ts
@@ -1,5 +1,6 @@
 import { UnsupportedMediaTypeException } from '@nestjs/common';
 import { fileMimetypeFilter } from './file-mimetype.filter';
+import { ZIP_MIME_TYPES } from '../constants/zip-mime-types';
 
 describe('fileMimetypeFilter', () => {
   const makeFile = (mimetype: string): Express.Multer.File => ({
@@ -30,6 +31,36 @@ describe('fileMimetypeFilter', () => {
     filter({}, makeFile('image/jpeg'), callback);
 
     expect(callback).toHaveBeenCalledWith(null, true);
+  });
+
+  it('accepts a zip uploaded from Windows', () => {
+    const filter = fileMimetypeFilter(...ZIP_MIME_TYPES);
+    const callback = jest.fn<void, [Error | null, boolean]>();
+
+    filter({}, makeFile('application/x-zip-compressed'), callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
+  });
+
+  it('accepts a zip uploaded from Linux or macOS', () => {
+    const filter = fileMimetypeFilter(...ZIP_MIME_TYPES);
+    const callback = jest.fn<void, [Error | null, boolean]>();
+
+    filter({}, makeFile('application/zip'), callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
+  });
+
+  it('rejects a non-zip upload when zip mimetypes are required', () => {
+    const filter = fileMimetypeFilter(...ZIP_MIME_TYPES);
+    const callback = jest.fn<void, [Error | null, boolean]>();
+
+    filter({}, makeFile('application/pdf'), callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.any(UnsupportedMediaTypeException),
+      false
+    );
   });
 
   it('rejects when mimetype does not match', () => {

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -49,6 +49,7 @@ import { UnitCommentService } from './unit-comment.service';
 import { UnitRichNoteService } from './unit-rich-note.service';
 import User from '../entities/user.entity';
 import { ItemUuidLookup } from '../interfaces/item-uuid-lookup.interface';
+import { ZIP_MIME_TYPES } from '../constants/zip-mime-types';
 import {
   EXPORT_REPORT_FILENAME,
   LanguageCodedText,
@@ -959,13 +960,8 @@ export class WorkspaceService {
     functionReturn: RequestReportDto
   ): FileIo[] {
     const files: FileIo[] = [];
-    const zipMimeTypes = [
-      'application/zip',
-      'application/x-zip-compressed',
-      'multipart/x-zip'
-    ];
     originalFiles.forEach(f => {
-      if (zipMimeTypes.indexOf(f.mimetype) >= 0) {
+      if (ZIP_MIME_TYPES.indexOf(f.mimetype) >= 0) {
         try {
           const zip = new AdmZip(f.buffer);
           const zipEntries = zip.getEntries();


### PR DESCRIPTION
Closes #969

## Problem

Beim Upload eines Ressourcen-Pakets (z. B. `GeoGebra.itcr.zip`) unter **Windows** schlägt der Upload mit `app-http-error.415` fehl. Dieselbe Datei lässt sich unter Linux und macOS problemlos hochladen – unabhängig vom Browser (Firefox und Edge gleichermaßen betroffen).

## Ursache

Den `Content-Type` einer hochgeladenen Datei liefert das Betriebssystem. Linux und macOS melden für `.zip` den Typ `application/zip`, Windows liest den Registry-Eintrag der Dateiendung und sendet üblicherweise `application/x-zip-compressed`.

Der Endpoint `POST /admin/resource-packages` erlaubte nur `application/zip`:

```ts
fileFilter: fileMimetypeFilter('application/zip')
```

Der multer-`fileFilter` verwirft die Datei damit bereits vor dem Service und wirft eine `UnsupportedMediaTypeException` → **415**.

Dass der Unit-Upload unter Windows funktioniert, liegt daran, dass `WorkspaceService.getZippedFiles` eine eigene, vollständigere Liste der zip-Mimetypes mitgebracht hat. Die beiden Stellen waren auseinandergelaufen.

## Lösung

- Neue geteilte Konstante `ZIP_MIME_TYPES` (`application/zip`, `application/x-zip-compressed`, `multipart/x-zip`) mit dem Grund für die Varianten dokumentiert.
- Der `fileFilter` des Resource-Package-Endpoints nutzt jetzt diese Liste.
- Die duplizierte lokale Liste in `WorkspaceService.getZippedFiles` wurde durch dieselbe Konstante ersetzt, damit Unit-Upload und Ressourcen-Paket-Upload nicht erneut divergieren.

Die Prüfung bleibt eine Allowlist – Nicht-Zip-Uploads werden weiterhin mit 415 abgelehnt.

## Tests

- Neu: `constants/zip-mime-types.spec.ts`
- Erweitert: `filters/file-mimetype.filter.spec.ts` um Regressionstests für den Windows-Mimetype, den Linux/macOS-Mimetype und die weiterhin greifende Ablehnung von Nicht-Zip-Dateien
- `nx test api`: 99 Suites / 746 Tests grün, `nx lint api` ohne Findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)