### PR TITLE
Unit-Tests im CI nicht mehr in Timeouts laufen lassen

### DIFF
--- a/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
+++ b/.gitlab-ci/Branch&PreRelease-Pipelines.gitlab-ci.yml
@@ -503,7 +503,10 @@ test-app:
     - !reference [ .default_rules, rules ]
   image: ${CI_REGISTRY_IMAGE}/${CICD_BASE_IMAGE}
   script:
-    - npx nx affected --base=HEAD~1 --target=test --parallel=2
+    # One project at a time and a bounded number of jest workers: two projects in
+    # parallel, each defaulting to (cores - 1) workers, oversubscribes the runner
+    # so far that specs which take milliseconds locally hit the jest timeout.
+    - npx nx affected --base=HEAD~1 --target=test --parallel=1 --maxWorkers=2
 
 #test-app-e2e:
 #  stage: test-e2e

--- a/.gitlab-ci/Release-Pipelines.gitlab-ci.yml
+++ b/.gitlab-ci/Release-Pipelines.gitlab-ci.yml
@@ -550,7 +550,8 @@ test-main-pr-backend:
     - echo "${CI_REGISTRY_PASSWORD}" | docker login -u ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     - docker pull --quiet ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test
   script:
-    - docker run ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test test api
+    # bounded jest workers, see test-app in Branch&PreRelease-Pipelines
+    - docker run ${BACKEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test test api --maxWorkers=2
   after_script:
     - docker logout ${CI_REGISTRY}
 
@@ -579,7 +580,8 @@ test-main-pr-frontend:
     - echo "${CI_REGISTRY_PASSWORD}" | docker login -u ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     - docker pull --quiet ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test
   script:
-    - docker run ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test test frontend
+    # bounded jest workers, see test-app in Branch&PreRelease-Pipelines
+    - docker run ${FRONTEND_IMAGE_NAME}:${CI_COMMIT_SHA}_test test frontend --maxWorkers=2
   after_script:
     - docker logout ${CI_REGISTRY}
 

--- a/apps/api/src/app/classes/download-docx.integration.spec.ts
+++ b/apps/api/src/app/classes/download-docx.integration.spec.ts
@@ -55,7 +55,6 @@ describe('DownloadDocx integration', () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    jest.setTimeout(15000);
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
 

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,5 +12,10 @@ module.exports = {
    * Example: "nx affected --targets=test --update-snapshot"
    * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
    */
-  snapshotFormat: { escapeString: true, printBasicPrototype: true }
+  snapshotFormat: { escapeString: true, printBasicPrototype: true },
+  // Jest's 5s default is measured against wall clock, so it fails on a loaded CI
+  // runner for tests that take milliseconds locally (module compilation on the
+  // first require, fake-timer advances over Angular's zone). The higher ceiling
+  // only affects how long a genuinely hanging test takes to report.
+  testTimeout: 30000
 };


### PR DESCRIPTION
Die api- und frontend-Suites fielen im CI wiederholt mit „Exceeded timeout of 5000 ms" aus, immer an denselben Stellen: die ersten drei Tests in `download-docx.integration.spec.ts` und der Auto-Logout-Test in `heartbeat.service.spec.ts`.

## Analyse

Die Tests sind nicht langsam. Lokal isoliert gemessen:

| | lokal | im CI |
|---|---|---|
| die drei DOCX-Tests | 75 ms / 15 ms / 21 ms | > 5000 ms → Abbruch |
| Heartbeat-Auto-Logout | 131 ms | > 5000 ms → Abbruch |

Im selben CI-Lauf brauchen bestandene Suites 38 s (`resource-package-not-found.exception.spec.ts`) bzw. 258 s (`is-workspace-group-admin.guard.spec.ts`). Die Tests wurden also ausgehungert, nicht falsch.

Zwei Ursachen:

1. **Der 5-Sekunden-Default von Jest ist ein Wall-Clock-Budget.** Unter Last reißt Arbeit das Limit, die lokal nichts kostet — die Kompilierung von `docx`/`mathml2omml` beim ersten `require` innerhalb eines Testkörpers, oder das Vorspulen von Fake-Timern durch Angulars Zone. Deshalb trifft es die *ersten* Tests einer Suite und nicht die späteren, die auf dem warmen Modulcache laufen.
2. **Der CI-Job hat zwei Projekte gleichzeitig getestet** (`--parallel=2`), jedes Jest mit dem Default von `Kerne-1` Workern. Auf einem Shared Runner sind das 2 × (n-1) ts-jest-Prozesse.

## Änderungen

- `jest.preset.js`: `testTimeout: 30000`. Das verlangsamt nichts außer der Meldedauer eines wirklich hängenden Tests.
- `test-app` (Branch-/PreRelease-Pipeline): `--parallel=1 --maxWorkers=2`.
- `test-main-pr-backend` / `test-main-pr-frontend` (Release-Pipeline): `--maxWorkers=2` an den Container durchgereicht (`ENTRYPOINT ["npx","nx"]`).
- `download-docx.integration.spec.ts`: der Aufruf `jest.setTimeout(15000)` im `beforeEach` ist entfernt. Er hatte nie eine Wirkung — `jest.setTimeout` schreibt nur `globalThis[Symbol.for('TEST_TIMEOUT_SYMBOL')]` (`jest-runtime/build/index.js:1714`), und jest-circus übernimmt den Wert ausschließlich im `run_start`-Handler (`jest-circus/build/jestAdapterInit.js:236-237`), der einmal vor allen Hooks feuert. Genau deshalb stand im Report 5000 ms und nicht 15000. Der Preset deckt den Fall jetzt ab.

## Verifikation

- `nx test api --maxWorkers=2 --showConfig` zeigt `"testTimeout": 30000` und `"maxWorkers": 2` — der Wert kommt durch nx tatsächlich bei Jest an.
- `nx run-many --target=test --projects=api,frontend --parallel=1 --maxWorkers=2` (also genau die CI-Form): 261 + 99 Suites, 2698 Tests grün.

Hinweis: Auf einer Maschine mit vielen Kernen kostet die Begrenzung Laufzeit (lokal 8 Kerne: knapp 4 min). Auf den Runnern ist genau diese Annahme falsch — dort ist weniger Parallelität schneller und vor allem stabil. Wenn die Runner-Größe schwankt, wäre `--maxWorkers=50%` die adaptive Variante; ein fester kleiner Wert ist in Containern verlässlicher, weil Node dort teils die Host-Kerne meldet.

Nicht Teil dieses PRs, aber im Log sichtbar und separat aufzuräumen: der api-Lauf hinterlässt offene Handles („A worker process has failed to exit gracefully", `SessionCleanupService`-Fehlerlogs), und der Heartbeat-Spec provoziert eine echte jsdom-Navigation (`heartbeat.service.ts:144` setzt `window.location.href`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)