### PR TITLE
Erwartete Fehlerausgaben aus dem Unit-Test-Log entfernen

### DIFF
--- a/apps/api/src/app/services/session-cleanup.service.spec.ts
+++ b/apps/api/src/app/services/session-cleanup.service.spec.ts
@@ -1,4 +1,5 @@
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { Logger } from '@nestjs/common';
 import { LessThan, Repository } from 'typeorm';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -10,8 +11,13 @@ describe('SessionCleanupService', () => {
   let service: SessionCleanupService;
   let userSessionRepository: DeepMocked<Repository<UserSession>>;
   let refreshTokenRepository: DeepMocked<Repository<RefreshToken>>;
+  let loggerErrorSpy: jest.SpyInstance;
 
   beforeEach(async () => {
+    // The swallowed cleanup errors below are expected; without this the suite
+    // prints them to stderr and a green CI run looks like a failed one.
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SessionCleanupService,
@@ -33,6 +39,7 @@ describe('SessionCleanupService', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   it('should be defined', () => {
@@ -57,6 +64,10 @@ describe('SessionCleanupService', () => {
       userSessionRepository.delete.mockRejectedValue(new Error('db down'));
 
       await expect(service.cleanupExpiredRows()).resolves.toBeUndefined();
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Cleanup of expired sessions failed.',
+        expect.stringContaining('db down')
+      );
     });
 
     it('should not throw when the refresh token delete fails', async () => {
@@ -64,6 +75,10 @@ describe('SessionCleanupService', () => {
       refreshTokenRepository.delete.mockRejectedValue(new Error('db down'));
 
       await expect(service.cleanupExpiredRows()).resolves.toBeUndefined();
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Cleanup of expired sessions failed.',
+        expect.stringContaining('db down')
+      );
     });
   });
 

--- a/apps/frontend/src/app/services/heartbeat.service.spec.ts
+++ b/apps/frontend/src/app/services/heartbeat.service.spec.ts
@@ -6,7 +6,7 @@ import { HeartbeatService } from './heartbeat.service';
 import { AppService } from './app.service';
 import { BackendService } from './backend.service';
 import {
-  ACTIVE_THRESHOLD_MS, PASSIVE_THRESHOLD_MS, ACTIVITY_SYNC_THROTTLE_MS
+  ACTIVE_THRESHOLD_MS, PASSIVE_THRESHOLD_MS, ACTIVITY_SYNC_THROTTLE_MS, AUTO_LOGOUT_REDIRECT_DELAY_MS
 } from '../app.constants';
 
 jest.mock('../app.constants', () => ({
@@ -52,6 +52,12 @@ describe('HeartbeatService', () => {
       ]
     });
   };
+
+  // The real implementation assigns window.location.href, which jsdom cannot
+  // perform and reports as an "Not implemented: navigation" error.
+  const stubRedirect = (): jest.SpyInstance => jest
+    .spyOn(service as unknown as { redirectToHome: () => void }, 'redirectToHome')
+    .mockImplementation();
 
   afterEach(() => {
     if (service) {
@@ -128,11 +134,32 @@ describe('HeartbeatService', () => {
     appServiceMock.authData = { userId: 1 } as AuthDataDto;
     configureTestingModule();
     service = TestBed.inject(HeartbeatService);
+    const redirectSpy = stubRedirect();
     service.start();
 
     await jest.advanceTimersByTimeAsync(ACTIVE_THRESHOLD_MS + PASSIVE_THRESHOLD_MS + 2000);
 
     expect(backendServiceMock.logout).toHaveBeenCalled();
+    expect(redirectSpy).toHaveBeenCalled();
+  });
+
+  it('should redirect only after the configured delay', async () => {
+    appServiceMock.authData = { userId: 1 } as AuthDataDto;
+    configureTestingModule();
+    service = TestBed.inject(HeartbeatService);
+    const redirectSpy = stubRedirect();
+    service.start();
+
+    // PASSIVE_THRESHOLD_MS is the total inactivity timeout, so the phases are
+    // depleted here; stop short of the redirect delay that starts at that point.
+    await jest.advanceTimersByTimeAsync(PASSIVE_THRESHOLD_MS + AUTO_LOGOUT_REDIRECT_DELAY_MS / 2);
+
+    expect(backendServiceMock.logout).toHaveBeenCalled();
+    expect(redirectSpy).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(AUTO_LOGOUT_REDIRECT_DELAY_MS);
+
+    expect(redirectSpy).toHaveBeenCalled();
   });
 
   it('should not log out while no user is logged in', async () => {
@@ -149,6 +176,7 @@ describe('HeartbeatService', () => {
     appServiceMock.authData = { userId: 1 } as AuthDataDto;
     configureTestingModule();
     service = TestBed.inject(HeartbeatService);
+    stubRedirect();
     service.start();
 
     appServiceMock.authData = { userId: 0 } as AuthDataDto;

--- a/apps/frontend/src/app/services/heartbeat.service.ts
+++ b/apps/frontend/src/app/services/heartbeat.service.ts
@@ -139,11 +139,7 @@ export class HeartbeatService implements OnDestroy {
     ).subscribe(() => {
       this.backendService.logout();
       // Delay redirect slightly so the user sees the fully depleted bar before redirect.
-      setTimeout(() => {
-        if (typeof window !== 'undefined') {
-          window.location.href = '/home';
-        }
-      }, AUTO_LOGOUT_REDIRECT_DELAY_MS);
+      setTimeout(() => this.redirectToHome(), AUTO_LOGOUT_REDIRECT_DELAY_MS);
     });
 
     this.activitySync$
@@ -186,6 +182,16 @@ export class HeartbeatService implements OnDestroy {
 
   stop(): void {
     this.started = false;
+  }
+
+  // Own method so tests can observe the auto-logout redirect by stubbing it:
+  // assigning window.location.href makes jsdom attempt a real navigation, which
+  // it cannot do and reports as an "Not implemented: navigation" error.
+  // eslint-disable-next-line class-methods-use-this
+  private redirectToHome(): void {
+    if (typeof window !== 'undefined') {
+      window.location.href = '/home';
+    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Nachtrag zu #1556: Dort standen zwei Nebenbefunde aus dem CI-Log offen — Fehlerausgaben in einem eigentlich grünen Lauf. Beide sind hier behoben.

## jsdom-Navigation im Heartbeat-Test

`heartbeat.service.ts` hat den Auto-Logout-Redirect direkt über `window.location.href` ausgeführt. jsdom kann nicht navigieren und protokolliert „Not implemented: navigation" samt vollem Stack — zweimal pro Lauf, auch lokal.

Die Zuweisung liegt jetzt in einer eigenen Methode `redirectToHome()`, die der Spec stubbt. Nebeneffekt: Der Redirect war bisher überhaupt nicht getestet. Jetzt ist abgedeckt, dass er ausgelöst wird und dass er erst nach `AUTO_LOGOUT_REDIRECT_DELAY_MS` feuert.

## Nest-ERROR-Logs im Session-Cleanup-Test

Zwei Tests lassen die Repository-Deletes absichtlich scheitern, um zu belegen, dass `cleanupExpiredRows` den Fehler verschluckt. Der `Logger.error`-Aufruf landete dabei auf stderr, was den Lauf im CI-Log wie einen Fehlschlag aussehen ließ. Der Logger wird jetzt gestubbt und der Vertrag „verschlucken und loggen" stattdessen zugesichert.

## Zum dritten Befund: „worker process has failed to exit gracefully"

Hier gibt es nichts zu reparieren — kein Leak gefunden:

- `--detectOpenHandles` über die vollständige api-Suite (99 Suites) und die vollständige frontend-Suite (261 Suites) meldet nichts.
- Die Warnung reproduziert lokal auch mit Workern nicht.
- Jest beendet einen Worker hart, wenn er nicht innerhalb von `FORCE_EXIT_DELAY` herunterfährt — 500 ms, `jest-worker/build/index.js:456`. Ein ausgehungerter Runner reißt das auch ohne jedes Leak.

Die Warnung ist damit Kollateral derselben Überlastung wie die Timeouts und sollte mit der Worker-Begrenzung aus #1556 verschwinden. Falls sie danach bleibt, wäre das ein neues Signal und einen eigenen Blick wert.

## Tests

- `nx run-many --target=test --projects=api,frontend --parallel=1 --maxWorkers=2`: 2699 Tests grün (frontend 1952, api 747)
- Heartbeat-Spec isoliert: 10 Tests grün, keine jsdom-Meldung mehr; Session-Cleanup-Spec: 6 Tests grün, keine ERROR-Ausgabe mehr
- `nx lint api frontend` fehlerfrei

Basiert auf `develop`, überschneidet sich nicht mit #1556 — die beiden können in beliebiger Reihenfolge gemergt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)