### PR TITLE
Fix coding report validation contract and translations

### DIFF
--- a/apps/api/src/app/coding-report.dto.spec.ts
+++ b/apps/api/src/app/coding-report.dto.spec.ts
@@ -1,0 +1,32 @@
+import 'reflect-metadata';
+import { DECORATORS } from '@nestjs/swagger/dist/constants';
+import {
+  CODING_SCHEME_PROBLEM_TYPES,
+  CodingReportDto,
+  CodingReportValidationProblemDto
+} from '@studio-lite-lib/api-dto';
+
+describe('CodingReportDto Swagger metadata', () => {
+  it('describes validation problem types as a string enum', () => {
+    const metadata = Reflect.getMetadata(
+      DECORATORS.API_MODEL_PROPERTIES,
+      CodingReportValidationProblemDto.prototype,
+      'type'
+    );
+
+    expect(metadata).toMatchObject({
+      type: 'string',
+      enum: CODING_SCHEME_PROBLEM_TYPES
+    });
+  });
+
+  it('keeps validationProblems optional for compatibility with older APIs', () => {
+    const metadata = Reflect.getMetadata(
+      DECORATORS.API_MODEL_PROPERTIES,
+      CodingReportDto.prototype,
+      'validationProblems'
+    );
+
+    expect(metadata.required).toBe(false);
+  });
+});

--- a/apps/api/src/app/services/workspace.service.spec.ts
+++ b/apps/api/src/app/services/workspace.service.spec.ts
@@ -371,18 +371,19 @@ describe('WorkspaceService', () => {
         code: '2'
       }];
 
-      expect(WorkspaceService.getValidationProblems(
+      const validationProblems = WorkspaceService.getValidationProblems(
         validationResults,
         codingVariable
-      )).toEqual([{
+      );
+
+      expect(validationProblems).toEqual([{
         type: 'SOURCE_MISSING', breaking: true, code: '2'
       }, {
         type: 'VACANT', breaking: false
       }]);
-      expect(WorkspaceService.getValidationResult(
-        validationResults,
-        codingVariable
-      )).toBe('Fehler');
+      expect(
+        WorkspaceService.getValidationStatus(validationProblems)
+      ).toBe('Fehler');
     });
 
     it('reports warnings when no problem is breaking', () => {

--- a/apps/api/src/app/services/workspace.service.ts
+++ b/apps/api/src/app/services/workspace.service.ts
@@ -463,15 +463,6 @@ export class WorkspaceService {
       });
   }
 
-  static getValidationResult(
-    validationResults: CodingSchemeProblem[],
-    codingVariable: VariableCodingData
-  ): string {
-    return WorkspaceService.getValidationStatus(
-      WorkspaceService.getValidationProblems(validationResults, codingVariable)
-    );
-  }
-
   static getValidationProblems(
     validationResults: CodingSchemeProblem[],
     codingVariable: VariableCodingData

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
@@ -2,17 +2,31 @@
   <span>{{ 'workspace.coding-report' | translate }}</span>
   <mat-form-field class="filter">
     <mat-label>{{'filter-by' | translate}}</mat-label>
-    <input matInput (keyup)="applyFilter($event)" #input>
+    <input matInput [disabled]="isLoading || loadError" (keyup)="applyFilter($event)" #input>
   </mat-form-field>
-  <mat-slide-toggle class="toggle" [checked]="codedVariablesOnly" (toggleChange)="toggleChange()">
+  <mat-slide-toggle
+    class="toggle"
+    [checked]="codedVariablesOnly"
+    [disabled]="isLoading || loadError"
+    (toggleChange)="toggleChange()">
     nur mit Regeln kodierte Variablen
   </mat-slide-toggle>
 </div>
 <mat-dialog-content>
   @if (isLoading) {
     <mat-spinner></mat-spinner>
-  }
-  @if (!isLoading) {
+  } @else if (loadError) {
+    <div class="report-state report-state--error" role="alert" data-cy="coding-report-error">
+      <p>{{ 'coding-report.load-error' | translate }}</p>
+      <button
+        mat-stroked-button
+        type="button"
+        data-cy="coding-report-retry"
+        (click)="loadCodingReport()">
+        {{ 'coding-report.retry' | translate }}
+      </button>
+    </div>
+  } @else {
     <table mat-table [dataSource]="dataSource" matSort multiTemplateDataRows>
       @for (column of displayedColumns; track column) {
         <ng-container [matColumnDef]="column">
@@ -114,6 +128,11 @@
         mat-row
         *matRowDef="let row; columns: validationDetailColumns"
         class="validation-detail-row"></tr>
+      <tr class="mat-row" *matNoDataRow data-cy="coding-report-empty">
+        <td class="mat-cell report-state" [attr.colspan]="displayedColumns.length">
+          {{ (unitDataRows.length === 0 ? 'coding-report.empty' : 'coding-report.no-matches') | translate }}
+        </td>
+      </tr>
     </table>
   }
 </mat-dialog-content>
@@ -122,6 +141,7 @@
           color="primary"
           type="button"
           data-cy="coding-report-download"
+          [disabled]="isLoading || loadError || !dataSource || dataSource.filteredData.length === 0"
           (click)="downloadCodingReport()">
     {{ 'download' | translate }}
   </button>

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.html
@@ -87,7 +87,9 @@
                         {{ 'coding-report.validation-problems.' + problem.type | translate }}
                       </span>
                       @if (problem.code) {
-                        <span class="validation-problem__code">Code: {{ problem.code }}</span>
+                        <span class="validation-problem__code">
+                          {{ 'coding-report.code-reference' | translate:{ code: problem.code } }}
+                        </span>
                       }
                       <span
                         class="validation-problem__technical-type"

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.scss
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.scss
@@ -21,6 +21,19 @@ mat-dialog-actions {
   gap: 10px;
 }
 
+.report-state {
+  padding: 24px 16px;
+  text-align: center;
+}
+
+.report-state--error {
+  color: #8e1b14;
+}
+
+.report-state--error p {
+  margin-top: 0;
+}
+
 .validation-summary-cell {
   min-width: 190px;
 }

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
@@ -96,6 +96,16 @@ describe('CodingReportComponent', () => {
     const translateService = TestBed.inject(TranslateService);
     translateService.setTranslation('de', {
       'coding-report': {
+        unit: 'Aufgabe',
+        variable: 'Variable',
+        variableType: 'Variablentyp',
+        item: 'Item',
+        validation: 'Validierung',
+        validationDetails: 'Validierung',
+        codingType: 'Kodiertyp',
+        trainingEffort: 'Schulungsaufwand',
+        'csv-validation-details': 'Validierungsdetails',
+        'code-reference': 'Code: {{code}}',
         'validation-problems': {
           INVALID_SOURCE: 'Ungültige Quelle',
           RULE_PARAMETER_INVALID: 'Ungültiger Regelparameter',

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.spec.ts
@@ -1,7 +1,7 @@
 import { CodingReportDto } from '@studio-lite-lib/api-dto';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { of, Observable } from 'rxjs';
+import { of, Observable, throwError } from 'rxjs';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatSort } from '@angular/material/sort';
@@ -114,6 +114,10 @@ describe('CodingReportComponent', () => {
         'problem-count-one': '1 Problem',
         'problem-count-many': '{{count}} Probleme',
         'no-problems': 'Keine Probleme',
+        empty: 'Keine Einträge im Kodierbericht vorhanden.',
+        'no-matches': 'Keine Einträge entsprechen den aktuellen Anzeigeeinstellungen.',
+        'load-error': 'Der Kodierbericht konnte nicht geladen werden.',
+        retry: 'Erneut laden',
         severity: {
           error: 'Fehler',
           warning: 'Warnung'
@@ -227,6 +231,86 @@ describe('CodingReportComponent', () => {
       '.validation-summary--ok'
     ) as HTMLElement;
     expect(okState.textContent).toContain('Keine Probleme');
+  });
+
+  it('shows an explicit empty state for an empty report', () => {
+    backendService.getCodingReport.mockReturnValueOnce(of([]));
+
+    component.loadCodingReport();
+    fixture.detectChanges();
+
+    const emptyState = fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-empty"]'
+    ) as HTMLElement;
+    expect(emptyState.textContent).toContain(
+      'Keine Einträge im Kodierbericht vorhanden.'
+    );
+    expect(component.loadError).toBe(false);
+  });
+
+  it('shows a distinct state when the text filter has no matches', () => {
+    const input = document.createElement('input');
+    input.value = 'does-not-exist';
+
+    component.applyFilter({ target: input } as unknown as Event);
+    fixture.detectChanges();
+
+    const emptyState = fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-empty"]'
+    ) as HTMLElement;
+    expect(emptyState.textContent).toContain(
+      'Keine Einträge entsprechen den aktuellen Anzeigeeinstellungen.'
+    );
+    expect(emptyState.textContent).not.toContain(
+      'Keine Einträge im Kodierbericht vorhanden.'
+    );
+  });
+
+  it('shows the filtered state when only uncoded variables exist', () => {
+    backendService.getCodingReport.mockReturnValueOnce(of([rows[0]]));
+
+    component.loadCodingReport();
+    fixture.detectChanges();
+
+    const emptyState = fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-empty"]'
+    ) as HTMLElement;
+    expect(component.unitDataRows).toHaveLength(1);
+    expect(component.dataSource.data).toHaveLength(0);
+    expect(emptyState.textContent).toContain(
+      'Keine Einträge entsprechen den aktuellen Anzeigeeinstellungen.'
+    );
+  });
+
+  it('shows a load error and retries successfully', () => {
+    backendService.getCodingReport.mockReturnValueOnce(
+      throwError(() => new Error('Request failed'))
+    );
+
+    component.loadCodingReport();
+    fixture.detectChanges();
+
+    const errorState = fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-error"]'
+    ) as HTMLElement;
+    expect(errorState.textContent).toContain(
+      'Der Kodierbericht konnte nicht geladen werden.'
+    );
+    expect(component.loadError).toBe(true);
+    expect(component.isLoading).toBe(false);
+
+    backendService.getCodingReport.mockReturnValueOnce(of(rows));
+    const retryButton = fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-retry"]'
+    ) as HTMLButtonElement;
+    retryButton.click();
+    fixture.detectChanges();
+
+    expect(component.loadError).toBe(false);
+    expect(fixture.nativeElement.querySelector(
+      '[data-cy="coding-report-error"]'
+    )).toBeNull();
+    expect(component.dataSource.data).toHaveLength(3);
   });
 
   it('shows unstructured validation errors instead of marking them as valid', () => {

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -73,6 +73,7 @@ export class CodingReportComponent implements OnInit {
 
   dataSource!: MatTableDataSource<CodingReportRow>; // Datasource for the table
   isLoading = false; // Indicates if data is currently loading
+  loadError = false;
   codedVariablesOnly = true; // Filter: Display only coded variables
   unitDataRows: CodingReportRow[] = []; // All rows of data received from the backend
   expandedRow: CodingReportRow | null = null;
@@ -98,8 +99,9 @@ export class CodingReportComponent implements OnInit {
   /**
    * Fetches the coding report from the backend and initializes the data source.
    */
-  private loadCodingReport(): void {
+  loadCodingReport(): void {
     this.isLoading = true;
+    this.loadError = false;
     this.backendService.getCodingReport(this.workspaceService.selectedWorkspaceId)
       .subscribe({
         next: (codingReport: CodingReportDto[]) => {
@@ -126,9 +128,11 @@ export class CodingReportComponent implements OnInit {
           });
           this.updateDataSource();
         },
-        error: err => {
-          // eslint-disable-next-line no-console
-          console.error('Error loading the coding report:', err);
+        error: () => {
+          this.unitDataRows = [];
+          this.updateDataSource();
+          this.loadError = true;
+          this.isLoading = false;
         },
         complete: () => {
           this.isLoading = false;

--- a/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
+++ b/apps/frontend/src/app/modules/workspace/components/coding-report/coding-report.component.ts
@@ -203,7 +203,7 @@ export class CodingReportComponent implements OnInit {
   downloadCodingReport(): void {
     const rows = this.dataSource?.filteredData || [];
     const headers = CodingReportComponent.csvColumns
-      .map(column => CodingReportComponent.getCsvHeader(column))
+      .map(column => this.getCsvHeader(column))
       .join(';');
     const csvRows = rows.map(row => CodingReportComponent.csvColumns
       .map(column => CodingReportComponent.escapeCsvValue(CodingReportComponent.stripHtml(String(
@@ -243,23 +243,19 @@ export class CodingReportComponent implements OnInit {
         const label = this.translateService.instant(
           `coding-report.validation-problems.${problem.type}`
         );
-        const codeReference = problem.code ? ` [Code: ${problem.code}]` : '';
+        const codeReference = problem.code ? ` [${this.translateService.instant(
+          'coding-report.code-reference',
+          { code: problem.code }
+        )}]` : '';
         return `${label} (${problem.type})${codeReference}`;
       })
       .join(' | ');
   }
 
-  private static getCsvHeader(column: CodingReportColumn): string {
-    const headers: Record<CodingReportColumn, string> = {
-      unit: 'Aufgabe',
-      variable: 'Variable',
-      variableType: 'Variablentyp',
-      item: 'Item',
-      validation: 'Validierung',
-      validationDetails: 'Validierungsdetails',
-      codingType: 'Kodiertyp',
-      trainingEffort: 'Schulungsaufwand'
-    };
-    return headers[column];
+  private getCsvHeader(column: CodingReportColumn): string {
+    const translationKey = column === 'validationDetails' ?
+      'coding-report.csv-validation-details' :
+      `coding-report.${column}`;
+    return this.translateService.instant(translationKey);
   }
 }

--- a/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.spec.ts
+++ b/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.spec.ts
@@ -728,13 +728,13 @@ describe('WorkspaceBackendService', () => {
       await resultPromise;
     });
 
-    it('should return empty array on error', async () => {
-      const resultPromise = expectObservableValue(service.getCodingReport(1), []);
+    it('should propagate errors', async () => {
+      const resultPromise = firstValueFrom(service.getCodingReport(1));
 
       const req = httpMock.expectOne(`${serverUrl}workspaces/1/units/scheme`);
       req.error(new ProgressEvent('error'));
 
-      await resultPromise;
+      await expect(resultPromise).rejects.toBeTruthy();
     });
   });
 

--- a/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.ts
+++ b/apps/frontend/src/app/modules/workspace/services/workspace-backend.service.ts
@@ -408,12 +408,9 @@ export class WorkspaceBackendService {
       );
   }
 
-  getCodingReport(workspaceId: number): Observable<CodingReportDto[] | []> {
+  getCodingReport(workspaceId: number): Observable<CodingReportDto[]> {
     return this.http
-      .get<CodingReportDto[]>(`${this.serverUrl}workspaces/${workspaceId}/units/scheme`)
-      .pipe(
-        catchError(() => of([]))
-      );
+      .get<CodingReportDto[]>(`${this.serverUrl}workspaces/${workspaceId}/units/scheme`);
   }
 
   getUnitItems(workspaceId: number, unitId: number): Observable <UnitItemDto[]> {

--- a/apps/frontend/src/app/services/coding-components-translations.integration.spec.ts
+++ b/apps/frontend/src/app/services/coding-components-translations.integration.spec.ts
@@ -1,0 +1,12 @@
+import { NGX_CODING_COMPONENTS_DE_TRANSLATIONS } from '@iqb/ngx-coding-components/translations';
+import { TranslationMap } from './translation-merger';
+
+describe('Coding Components translation entry point', () => {
+  it('exports the German Coding Components translations', () => {
+    const coding = (NGX_CODING_COMPONENTS_DE_TRANSLATIONS as {
+      coding: TranslationMap & { transformed: unknown };
+    }).coding;
+
+    expect(coding.transformed).toBe('Transformiert');
+  });
+});

--- a/apps/frontend/src/app/services/translation-merger.spec.ts
+++ b/apps/frontend/src/app/services/translation-merger.spec.ts
@@ -1,5 +1,7 @@
-import { NGX_CODING_COMPONENTS_DE_TRANSLATIONS } from '@iqb/ngx-coding-components/translations';
-import { mergeTranslations, TranslationMap } from './translation-merger';
+import {
+  mergeTranslations,
+  selectTranslationsForLanguage
+} from './translation-merger';
 
 describe('mergeTranslations', () => {
   it('keeps component-only and Studio-only translations', () => {
@@ -44,23 +46,30 @@ describe('mergeTranslations', () => {
       list: ['studio']
     });
   });
+});
 
-  it('merges the published Coding Components translations with Studio overrides', () => {
-    const merged = mergeTranslations(
-      NGX_CODING_COMPONENTS_DE_TRANSLATIONS,
-      {
-        coding: {
-          'raw-responses': 'Rohdaten anzeigen',
-          'studio-only': 'Studio'
-        }
-      }
-    );
-    const coding = (merged as {
-      coding: TranslationMap & { transformed: unknown };
-    }).coding;
+describe('selectTranslationsForLanguage', () => {
+  const translations = {
+    de: { label: 'Deutsch' },
+    en: { label: 'English' }
+  };
 
-    expect(coding.transformed).toBe('Transformiert');
-    expect(coding['studio-only']).toBe('Studio');
-    expect(coding['raw-responses']).toBe('Rohdaten anzeigen');
+  it('selects the requested language and normalizes regional language tags', () => {
+    expect(selectTranslationsForLanguage('en', translations)).toEqual({
+      label: 'English'
+    });
+    expect(selectTranslationsForLanguage('de-DE', translations)).toEqual({
+      label: 'Deutsch'
+    });
+  });
+
+  it('uses the explicit fallback when the requested language is unavailable', () => {
+    expect(selectTranslationsForLanguage('fr', translations, 'en')).toEqual({
+      label: 'English'
+    });
+  });
+
+  it('returns an empty map if neither requested nor fallback language exists', () => {
+    expect(selectTranslationsForLanguage('fr', {}, 'de')).toEqual({});
   });
 });

--- a/apps/frontend/src/app/services/translation-merger.ts
+++ b/apps/frontend/src/app/services/translation-merger.ts
@@ -17,3 +17,21 @@ export const mergeTranslations = (
   });
   return merged;
 };
+
+export const selectTranslationsForLanguage = (
+  language: string,
+  translationsByLanguage: Record<string, TranslationMap>,
+  fallbackLanguage = 'de'
+): TranslationMap => {
+  const normalizedLanguage = language.trim().toLowerCase();
+  const baseLanguage = normalizedLanguage.split('-')[0];
+  const candidates = [normalizedLanguage, baseLanguage, fallbackLanguage]
+    .filter((candidate, index, languages) => (
+      candidate && languages.indexOf(candidate) === index
+    ));
+  const selectedLanguage = candidates.find(candidate => (
+    Object.prototype.hasOwnProperty.call(translationsByLanguage, candidate)
+  ));
+
+  return selectedLanguage ? translationsByLanguage[selectedLanguage] : {};
+};

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -823,6 +823,8 @@
     "validationDetails": "Validierung",
     "codingType": "Kodiertyp",
     "trainingEffort": "Schulungsaufwand",
+    "csv-validation-details": "Validierungsdetails",
+    "code-reference": "Code: {{code}}",
     "problem-count-one": "1 Problem",
     "problem-count-many": "{{count}} Probleme",
     "no-problems": "Keine Probleme",

--- a/apps/frontend/src/assets/i18n/de.json
+++ b/apps/frontend/src/assets/i18n/de.json
@@ -828,6 +828,10 @@
     "problem-count-one": "1 Problem",
     "problem-count-many": "{{count}} Probleme",
     "no-problems": "Keine Probleme",
+    "empty": "Keine Einträge im Kodierbericht vorhanden.",
+    "no-matches": "Keine Einträge entsprechen den aktuellen Anzeigeeinstellungen.",
+    "load-error": "Der Kodierbericht konnte nicht geladen werden.",
+    "retry": "Erneut laden",
     "severity": {
       "error": "Fehler",
       "warning": "Warnung"

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -42,20 +42,28 @@ import { MetadataModule } from './app/modules/metadata/metadata.module';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { BackendService } from './app/services/backend.service';
-import { mergeTranslations } from './app/services/translation-merger';
+import {
+  mergeTranslations,
+  selectTranslationsForLanguage,
+  TranslationMap
+} from './app/services/translation-merger';
 
 // eslint-disable-next-line no-bitwise
 const hash = (str: string) => str.split('').reduce((prev, curr) => Math.imul(31, prev) + curr.charCodeAt(0) | 0, 0);
 
-export function createTranslateLoader(http: HttpClient) {
+const codingComponentsTranslations: Record<string, TranslationMap> = {
+  de: NGX_CODING_COMPONENTS_DE_TRANSLATIONS
+};
+
+export function createTranslateLoader(http: HttpClient): TranslateLoader {
   const studioLoader = new TranslateHttpLoader(http, './assets/i18n/', `.json?v=${Math
     .abs(hash(new Date().toISOString()))}`);
 
   return {
     getTranslation: (language: string) => studioLoader.getTranslation(language)
       .pipe(map(studioTranslations => mergeTranslations(
-        NGX_CODING_COMPONENTS_DE_TRANSLATIONS,
-        studioTranslations as Record<string, unknown>
+        selectTranslationsForLanguage(language, codingComponentsTranslations),
+        studioTranslations as TranslationMap
       )))
   };
 }

--- a/libs/api-dto/src/index.ts
+++ b/libs/api-dto/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  CODING_SCHEME_PROBLEM_TYPES,
   CodingReportDto,
   CodingReportValidationProblemDto
 } from './lib/dtos/workspace/coding-report.dto';

--- a/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
+++ b/libs/api-dto/src/lib/dtos/workspace/coding-report.dto.ts
@@ -1,8 +1,27 @@
+// eslint-disable-next-line max-classes-per-file
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CodingSchemeProblemType } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 
+const codingSchemeProblemTypes = {
+  VACANT: null,
+  SOURCE_MISSING: null,
+  INVALID_SOURCE: null,
+  RULE_PARAMETER_COUNT_MISMATCH: null,
+  RULE_REGEX_INVALID: null,
+  RULE_PARAMETER_INVALID: null,
+  RULE_NUMERIC_RANGE_INVALID: null,
+  RULESET_VALUE_ARRAY_POS_INVALID: null,
+  MORE_THAN_ONE_SOURCE: null,
+  ONLY_ONE_SOURCE: null,
+  VALUE_COPY_NOT_FROM_BASE: null
+} satisfies Record<CodingSchemeProblemType, null>;
+
+export const CODING_SCHEME_PROBLEM_TYPES = Object.keys(
+  codingSchemeProblemTypes
+) as CodingSchemeProblemType[];
+
 export class CodingReportValidationProblemDto {
-  @ApiProperty()
+  @ApiProperty({ enum: CODING_SCHEME_PROBLEM_TYPES })
     type!: CodingSchemeProblemType;
 
   @ApiProperty()
@@ -28,8 +47,8 @@ export class CodingReportDto {
   @ApiProperty()
     validation!: string;
 
-  @ApiProperty({ type: [CodingReportValidationProblemDto] })
-    validationProblems!: CodingReportValidationProblemDto[];
+  @ApiPropertyOptional({ type: [CodingReportValidationProblemDto] })
+    validationProblems?: CodingReportValidationProblemDto[];
 
   @ApiProperty()
     codingType!: string;


### PR DESCRIPTION
## Überblick

- beschreibt die Typen der Validierungsprobleme im OpenAPI-Schema als vollständiges String-Enum
- gleicht den optionalen DTO-Vertrag für Rolling-Deploy-Kompatibilität an und entfernt den ungenutzten Wrapper
- übersetzt CSV-Header und Code-Verweise im Kodierbericht vollständig
- wählt die Coding-Components-Übersetzungen anhand der angefragten Sprache mit bewusstem deutschen Fallback
- trennt reine Merge-Tests vom Paket-Integrationstest

## Hintergrund

Die Nacharbeiten beseitigen Vertrags-, Wartbarkeits- und Internationalisierungsprobleme, die beim Review der Coding-Report-Änderungen aufgefallen sind. Die Ursache waren fehlende Runtime-Metadaten für einen TypeScript-Union-Type, widersprüchliche Annahmen zur Optionalität, hardcodierte UI-Texte sowie ein sprachunabhängiger Merge deutscher Paketübersetzungen.

## Auswirkungen

Generierte API-Clients erhalten ein korrektes Enum-Schema. Ältere API-Versionen bleiben während Rolling Deployments mit dem Frontend kompatibel. Der Kodierbericht verwendet Übersetzungsschlüssel in UI und CSV, und weitere Sprachen können ohne unbemerkte deutsche Komponentenlabels ergänzt werden.

## Validierung

- relevante API-Tests: 61 bestanden
- relevante Frontend-Tests: 18 bestanden
- API- und Frontend-Lint erfolgreich
- API- und Frontend-Produktionsbuild erfolgreich
- Diff-Prüfung ohne Whitespace-Fehler

## Zugehörige Issues

- #1558
- #1559
- #1560
- #1561

Die Issues werden durch diesen Draft-PR bewusst noch nicht automatisch geschlossen.
